### PR TITLE
fix SCP command to use -O option

### DIFF
--- a/src/launch_conformance_tests_ssh.sh
+++ b/src/launch_conformance_tests_ssh.sh
@@ -14,7 +14,7 @@ SSH() {
 }
 
 SCP() {
-	sshpass -p "${board_password}" scp -o StrictHostKeyChecking=no "$@"
+	sshpass -p "${board_password}" scp -O -o StrictHostKeyChecking=no "$@"
 }
 
 connect_and_transfer_with_ssh() {


### PR DESCRIPTION
This commit is adding the -O option to the SCP command. This option allows using the legacy scp protocol instead of the SFTP protocol. The use of the SFTP protocol is not supported on certain platforms then prefer SCP command to use the legacy protocol.