### PR TITLE
launch_conformance_tests: update help message

### DIFF
--- a/launch_conformance_tests.sh
+++ b/launch_conformance_tests.sh
@@ -30,8 +30,8 @@ or
   --serial <serial_port>  Specify the serial port of the board to run tests on
 
 Optional options:
-  --user <username>   Specify the username for SSH connection (default: root)
-  --password <password>  Specify the password for SSH connection (default: empty)
+  --user <username>   Specify the username for SSH and serial connection (default: root)
+  --password <password>  Specify the password for SSH and serial connection (default: empty)
   --no-reports        Do not generate test reports (only run tests and display results)
   --baudrate <baudrate> Specify the baudrate for the serial port of the board (default: 115200)
   --help              Show this help message


### PR DESCRIPTION
User and password options are used for both SSH and serial connections. Then update the help message to reflect this.