### PR TITLE
launch_conformance_tests_ssh: add ipv6 support

### DIFF
--- a/src/launch_conformance_tests_ssh.sh
+++ b/src/launch_conformance_tests_ssh.sh
@@ -41,7 +41,7 @@ connect_and_transfer_with_ssh() {
 
 	echo ""
 	echo "Copying conformance test files to board"
-	SCP -r "${topdir}"/src "${board_user}@${board_ip}:/tmp/conformance_tests" 1>/dev/null || {
+	SCP -r "${topdir}"/src "${board_user}@[${board_ip}]:/tmp/conformance_tests" 1>/dev/null || {
 		echo -e "${RED}Error:${ENDCOLOR} Failed to copy test files to board"
 		exit 1
 	}
@@ -61,7 +61,7 @@ launch_tests_with_report_ssh() {
 	echo ""
 	echo "Copying tests report on host"
 	mkdir -p "${topdir}"/reports
-	SCP "${board_user}@${board_ip}:/tmp/conformance_tests/cukinia-tests/geisa-conformance-report.xml" "${topdir}"/reports 1>/dev/null || {
+	SCP "${board_user}@[${board_ip}]:/tmp/conformance_tests/cukinia-tests/geisa-conformance-report.xml" "${topdir}"/reports 1>/dev/null || {
 		echo -e "${RED}Error:${ENDCOLOR} Failed to copy test report from board"
 		exit 1
 	}


### PR DESCRIPTION
In order to support both IPv4 and IPv6 addresses for the board, the SCP commands have been modified to use the square bracket notation for the IP address. Without this notation, the SCP command is unable to distinguish an IPv6 address.