### PR TITLE
os_requirements_tests: change NTP tests

### DIFF
--- a/src/cukinia-tests/tests.d/03-os_requirements_tests.conf
+++ b/src/cukinia-tests/tests.d/03-os_requirements_tests.conf
@@ -42,10 +42,6 @@ cukinia_test $(cat /etc/resolv.conf | grep -c "nameserver") -gt 0
 as "Checking Domain Name Service (DNS) is working" \
 cukinia_cmd getent hosts github.com
 
-when "command -v timedatectl" \
-as "Checking Network Time Protocol (NTP) is used (with timedatectl)" \
-cukinia_test $(timedatectl status 2>/dev/null | grep -c "NTP service: active") -gt 0
-
-when "command -v chronyc" \
-as "Checking Network Time Protocol (NTP) is used (with chronyc)" \
-cukinia_test $(chronyc tracking 2>/dev/null | grep -c "Leap status     : Normal") -gt 0
+unless "[ -z $CURRENT_DATE_UTC ]" \
+as "Checking Network Time Protocol (NTP) is used (Current date: $(date -u +'%Y-%m-%d_%H:%M')) (Skipped if host date variable is not set)" \
+cukinia_test $(date -u +"%Y-%m-%d_%H:%M" | grep -c "$CURRENT_DATE_UTC") -eq 1

--- a/src/launch_conformance_tests_serial.py
+++ b/src/launch_conformance_tests_serial.py
@@ -7,6 +7,7 @@ version 2.0. See LICENSE for details.
 """
 
 import argparse
+from datetime import datetime
 import fcntl
 import os
 import subprocess
@@ -143,9 +144,12 @@ def launch_cukinia_tests(p, args):
     Launch Cukinia tests on the board.
     If --no-reports is specified, only run tests and display results without generating reports.
     """
+    # Get host date for NTP test
+    current_date_utc = datetime.now().strftime("%Y-%m-%d_%H:%M")
     try:
         if args.no_reports:
             p.sendline(
+                f"CURRENT_DATE_UTC={current_date_utc} "
                 "/tmp/conformance_tests/cukinia/cukinia "
                 "/tmp/conformance_tests/cukinia-tests/cukinia.conf"
             )
@@ -154,6 +158,7 @@ def launch_cukinia_tests(p, args):
             test_exit_code = get_cukinia_return_code(p)
         else:
             p.sendline(
+                f"CURRENT_DATE_UTC={current_date_utc} "
                 "/tmp/conformance_tests/cukinia/cukinia -f junitxml "
                 "-o /tmp/conformance_tests/cukinia-tests/geisa-conformance-report.xml "
                 "/tmp/conformance_tests/cukinia-tests/cukinia.conf"

--- a/src/launch_conformance_tests_ssh.sh
+++ b/src/launch_conformance_tests_ssh.sh
@@ -53,9 +53,12 @@ launch_tests_with_report_ssh() {
 	local board_password="$3"
 	local topdir="$4"
 
+	# Get host date for NTP test
+	CURRENT_DATE_UTC=$(date -u +"%Y-%m-%d_%H:%M")
+
 	echo ""
 	echo "Launching tests..."
-	SSH "/tmp/conformance_tests/cukinia/cukinia -f junitxml -o /tmp/conformance_tests/cukinia-tests/geisa-conformance-report.xml /tmp/conformance_tests/cukinia-tests/cukinia.conf"
+	SSH "CURRENT_DATE_UTC=${CURRENT_DATE_UTC} /tmp/conformance_tests/cukinia/cukinia -f junitxml -o /tmp/conformance_tests/cukinia-tests/geisa-conformance-report.xml /tmp/conformance_tests/cukinia-tests/cukinia.conf"
 	test_exit_code=$?
 
 	echo ""
@@ -74,9 +77,12 @@ launch_tests_without_report_ssh() {
 	local board_user="$2"
 	local board_password="$3"
 
+	# Get host date for NTP test
+	CURRENT_DATE_UTC=$(date -u +"%Y-%m-%d_%H:%M")
+
 	echo ""
 	echo "Launching tests..."
-	SSH "/tmp/conformance_tests/cukinia/cukinia /tmp/conformance_tests/cukinia-tests/cukinia.conf"
+	SSH "CURRENT_DATE_UTC=${CURRENT_DATE_UTC} /tmp/conformance_tests/cukinia/cukinia /tmp/conformance_tests/cukinia-tests/cukinia.conf"
 	test_exit_code=$?
 
 	export test_exit_code


### PR DESCRIPTION
The previous NTP tests were checking for the presence of timedatectl and chronyc commands, which may not be available on all systems. To be sure that NTP is working, we now set the date to a known value (2025-01-01) and check if the system time is synchronizing the time correctly. This is done by checking if the current UTC date matches the UTC date before the set. If the test is not able to change the date, it will skip the test as the test will be always successful in this case.