### PR TITLE
launch_conformance_tests_ssh: add environment variable for ssh and scp

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -7,4 +7,4 @@ command='shellcheck -xo all launch_conformance_tests.sh src/launch_conformance_t
 && pylint src/launch_conformance_tests_serial.py && black --check --diff src/launch_conformance_tests_serial.py'
 user_extra_groups='dialout'
 
-docker_run_args='--network=host'
+docker_run_args='--network=host -e CONFORMANCE_SCP_ARGS -e CONFORMANCE_SSH_ARGS'

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Optional options:
 * `--baudrate <baudrate>`: The baudrate for the serial port of the board (default: 115200)
 * `--help`: display help message
 
+Environment variables can also be used to configure the script:
+* `CONFORMACE_SCP_ARGS`: Additional arguments for the `scp` command
+* `CONFORMACE_SSH_ARGS`: Additional arguments for the `ssh` command
+
 A xml and pdf report will be generated in the `reports` directory.
 
 To use the docker support run with the following commands:

--- a/src/launch_conformance_tests_ssh.sh
+++ b/src/launch_conformance_tests_ssh.sh
@@ -8,13 +8,17 @@
 
 RED="\e[31m"
 ENDCOLOR="\e[0m"
+declare CONFORMANCE_SSH_ARGS
+declare CONFORMANCE_SCP_ARGS
 
 SSH() {
-	sshpass -p "${board_password}" ssh -tt -o LogLevel=QUIET -o StrictHostKeyChecking=no "${board_user}@${board_ip}" "$@"
+	#shellcheck disable=SC2086
+	sshpass -p "${board_password}" ssh ${CONFORMANCE_SSH_ARGS} -tt -o LogLevel=QUIET -o StrictHostKeyChecking=no "${board_user}@${board_ip}" "$@"
 }
 
 SCP() {
-	sshpass -p "${board_password}" scp -O -o StrictHostKeyChecking=no "$@"
+	#shellcheck disable=SC2086
+	sshpass -p "${board_password}" scp ${CONFORMANCE_SCP_ARGS} -o StrictHostKeyChecking=no "$@"
 }
 
 connect_and_transfer_with_ssh() {


### PR DESCRIPTION
To allow users to pass additional arguments to the `ssh` and `scp` commands, we introduce two environment variables:
* `CONFORMANCE_SCP_ARGS`: Additional arguments for the `scp` command
* `CONFORMANCE_SSH_ARGS`: Additional arguments for the `ssh` command This allows for more flexibility in configuring the SSH connection and file transfer without modifying the script directly.

As the -O for `scp` is the support for the old SCP protocol, it is removed as it will be less and less used. If needed, users can add it back using the `CONFORMANCE_SCP_ARGS` environment variable.