### PR TITLE
launch_conformance_tests: update README and script help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ results.
 
 Optional options:
 
-* `--user <username>`: The username for SSH and serial connection (default: root)
-* `--password <password>`: The password for SSH and serial connection (default: empty)
+* `--user <username>`: The username for the target device (default: root)
+* `--password <password>`: The password for the target device (default: empty)
 * `--no-reports` : Do not generate test reports (only run tests and display results)
 * `--baudrate <baudrate>`: The baudrate for the serial port of the board (default: 115200)
 * `--help`: display help message

--- a/launch_conformance_tests.sh
+++ b/launch_conformance_tests.sh
@@ -31,8 +31,8 @@ or
   --serial <serial_port>  Specify the serial port of the board to run tests on
 
 Optional options:
-  --user <username>   Specify the username for SSH and serial connection (default: root)
-  --password <password>  Specify the password for SSH and serial connection (default: empty)
+  --user <username>   Specify the username for the target device (default: root)
+  --password <password>  Specify the password for the target device (default: empty)
   --no-reports        Do not generate test reports (only run tests and display results)
   --baudrate <baudrate> Specify the baudrate for the serial port of the board (default: 115200)
   --help              Show this help message


### PR DESCRIPTION
Instead of indicating the connection type, be more generic and indicate that the username and password are for the target device.