### PR TITLE
Make api tests more generic

### DIFF
--- a/.github/workflows/ci-conformance-on-target-serial.yml
+++ b/.github/workflows/ci-conformance-on-target-serial.yml
@@ -33,6 +33,8 @@ jobs:
               with:
                 ref: ${{ github.event.pull_request.head.sha || github.sha }}
                 submodules: true
+            - name: copy template file for launch_gapi_test_app.sh
+              run: cp launch_gapi_test_app.sh.template launch_gapi_test_app.sh
             - name: Run on target tests with report generation using serial
               run: |
                 cqfd init

--- a/.github/workflows/ci-conformance-on-target-ssh.yml
+++ b/.github/workflows/ci-conformance-on-target-ssh.yml
@@ -28,6 +28,8 @@ jobs:
               with:
                 ref: ${{ github.event.pull_request.head.sha || github.sha }}
                 submodules: true
+            - name: copy template file for launch_gapi_test_app.sh
+              run: cp launch_gapi_test_app.sh.template launch_gapi_test_app.sh
             - name: Run on target tests with report generation using ssh
               run: |
                 cqfd init

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cukinia.tar.gz
 GEISA-LEE-tests.tar.gz
 src/GEISA-API-tests/build_rootfs
 gapi-conformance-tests.squashfs
+launch_gapi_test_app.sh

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The automatic test launcher requires the following requirements:
     - podman (On ubuntu, install with `sudo apt install podman`)
     - qemu-user-static (On ubuntu, install with `sudo apt install qemu-user-static`)
     - mksquashfs (On ubuntu, install with `sudo apt install squashfs-tools`)
+    - launch_gapi_test_app.sh script see [API Launching script](#api-launching-script) section
 
 A docker support is also available to launch the tests with a container, it requires:
   - cqfd (See [requirements](https://github.com/savoirfairelinux/cqfd?tab=readme-ov-file#requirements) and [installation](https://github.com/savoirfairelinux/cqfd?tab=readme-ov-file#installingremoving-cqfd) steps on github)
@@ -269,3 +270,12 @@ you configured).
 * `<target_baudrate>` being the baudrate of your target (optional, default: 115200)
 * `<target_ip_password>` being the name of the secret containing the password
 of your target. (optional, if not provided, no password will be used for the serial connection)
+
+## API Launching script
+
+When executing the API tests using ssh, the `launch_gapi_test_app.sh` script is
+required to launch the test application on the target. This script is
+responsible for setting up the environment and executing the test application.
+Its goal is to provide a generic way to launch the test application on different
+targets and with different configurations.
+A template is available in `launch_gapi_test_app.sh.template`

--- a/launch_conformance_tests.sh
+++ b/launch_conformance_tests.sh
@@ -174,7 +174,7 @@ if [[ -z ${NO_GAPI_TESTS} ]]; then
 		if ! ${NO_REPORTS}; then
 			launch_gapi_tests_with_report "${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}" "${TOPDIR}"
 		else
-			launch_gapi_tests_without_report "${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}"
+			launch_gapi_tests_without_report "${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}" "${TOPDIR}"
 		fi
 		cleanup_api_ssh "${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}"
 	else

--- a/launch_conformance_tests.sh
+++ b/launch_conformance_tests.sh
@@ -176,7 +176,7 @@ if [[ -z ${NO_GAPI_TESTS} ]]; then
 		else
 			launch_gapi_tests_without_report "${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}" "${TOPDIR}"
 		fi
-		cleanup_api_ssh "${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}"
+		cleanup_api_ssh "${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}" "${TOPDIR}"
 	else
 		echo -e "${ORANGE}Warning:${ENDCOLOR} API test through serial is not supported yet."
 	fi

--- a/launch_gapi_test_app.sh.template
+++ b/launch_gapi_test_app.sh.template
@@ -33,6 +33,27 @@ launch_app_without_report() {
     -- /etc/cukinia/cukinia /etc/GEISA-API-tests/cukinia.conf
 }
 
+clean_up() {
+    if mountpoint -q /tmp/GAPI-tests/rootfs; then
+        umount /tmp/GAPI-tests/rootfs || {
+            echo -e "Error: Failed to unmount test filesystem on board"
+            exit 1
+        }
+    fi
+    if mountpoint -q /tmp/GAPI-tests/base; then
+        umount /tmp/GAPI-tests/base || {
+            echo -e "Error: Failed to unmount base filesystem on board"
+            exit 1
+        }
+    fi
+    if mountpoint -q /tmp/GAPI-tests/app; then
+        umount /tmp/GAPI-tests/app || {
+            echo -e "Error: Failed to unmount app filesystem on board"
+            exit 1
+        }
+    fi
+}
+
 case "$1" in
     "report")
         echo "Launching gapi_test_app with report configuration..."
@@ -41,6 +62,10 @@ case "$1" in
     "no-report")
         echo "Launching gapi_test_app with no-report configuration..."
         launch_app_without_report
+        ;;
+    "clean")
+        echo "Cleaning up mounted filesystems and temporary directories..."
+        clean_up
         ;;
     *)
         echo "Unknown argument: $1"

--- a/launch_gapi_test_app.sh.template
+++ b/launch_gapi_test_app.sh.template
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+mount_overlayfs_on_board() {
+    mount -t squashfs -o loop /etc/geisa/*.squashfs /tmp/GAPI-tests/base || {
+        echo -e "Error: Failed to mount base filesystem on board"
+        exit 1
+    }
+
+    mount -t squashfs -o loop /tmp/GAPI-tests/gapi-conformance-tests.squashfs /tmp/GAPI-tests/app || {
+        echo -e "Error: Failed to mount app filesystem on board"
+        exit 1
+    }
+
+    mount -t overlay overlay -o lowerdir=/tmp/GAPI-tests/base:/tmp/GAPI-tests/app,upperdir=/tmp/GAPI-tests/upper,workdir=/tmp/GAPI-tests/work /tmp/GAPI-tests/rootfs || {
+        echo -e "Error: Failed to mount overlay filesystem on board"
+        exit 1
+    }
+}
+
+launch_app_with_report() {
+    mount_overlayfs_on_board
+
+    lxc-execute -f /etc/lxc/default.conf -s lxc.uts.name=GAPI-tests \
+    -s lxc.rootfs.path=dir:/tmp/GAPI-tests/rootfs --share-net 1 -n GAPI-tests \
+    -- /etc/cukinia/cukinia -f junitxml -o /geisa-api-conformance-report.xml /etc/GEISA-API-tests/cukinia.conf
+}
+
+launch_app_without_report() {
+    mount_overlayfs_on_board
+
+    lxc-execute -f /etc/lxc/default.conf -s lxc.uts.name=GAPI-tests \
+    -s lxc.rootfs.path=dir:/tmp/GAPI-tests/rootfs --share-net 1 -n GAPI-tests \
+    -- /etc/cukinia/cukinia /etc/GEISA-API-tests/cukinia.conf
+}
+
+case "$1" in
+    "report")
+        echo "Launching gapi_test_app with report configuration..."
+        launch_app_with_report
+        ;;
+    "no-report")
+        echo "Launching gapi_test_app with no-report configuration..."
+        launch_app_without_report
+        ;;
+    *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+esac

--- a/src/launch_gapi_conformance_tests.sh
+++ b/src/launch_gapi_conformance_tests.sh
@@ -21,6 +21,28 @@ SCP() {
 	sshpass -p "${board_password}" scp ${CONFORMANCE_SCP_ARGS} -o StrictHostKeyChecking=no "$@"
 }
 
+transfer_launch_gapi_tests_script() {
+	local board_ip="$1"
+	local board_user="$2"
+	local board_password="$3"
+	local topdir="$4"
+
+	if [[ ! -f "${topdir}"/launch_gapi_test_app.sh ]]; then
+		echo -e "${RED}Error:${ENDCOLOR} No API launching script found. Create a launch_gapi_test_app.sh script (see launch_gapi_test_app.sh.template or read the README)"
+		exit 1
+	fi
+
+	SSH "mkdir -p /tmp/GAPI-tests" || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to create test directory on board"
+		exit 1
+	}
+
+	SCP "${topdir}"/launch_gapi_test_app.sh "${board_user}@[${board_ip}]:/tmp/GAPI-tests/launch_gapi_test_app.sh" 1>/dev/null || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to transfer API test launch script to board"
+		exit 1
+	}
+}
+
 create_gapi_test_squashfs() {
 	local topdir="$1"
 
@@ -93,12 +115,7 @@ launch_gapi_tests_with_report() {
 	echo ""
 	echo "Launching tests..."
 
-	if [[ ! -f "${topdir}"/launch_gapi_test_app.sh ]]; then
-		echo -e "${RED}Error:${ENDCOLOR} No API launching script found. Create a launch_gapi_test_app.sh script (see launch_gapi_test_app.sh.template or read the README)"
-		exit 1
-	fi
-
-	SCP "${topdir}"/launch_gapi_test_app.sh "${board_user}@[${board_ip}]:/tmp/GAPI-tests/launch_gapi_test_app.sh" 1>/dev/null || {
+	transfer_launch_gapi_tests_script "${board_ip}" "${board_user}" "${board_password}" "${topdir}" || {
 		echo -e "${RED}Error:${ENDCOLOR} Failed to transfer API test launch script to board"
 		exit 1
 	}
@@ -125,12 +142,7 @@ launch_gapi_tests_without_report() {
 	echo ""
 	echo "Launching tests..."
 
-	if [[ ! -f "${topdir}"/launch_gapi_test_app.sh ]]; then
-		echo -e "${RED}Error:${ENDCOLOR} No API launching script found. Create a launch_gapi_test_app.sh script (see launch_gapi_test_app.sh.template or read the README)"
-		exit 1
-	fi
-
-	SCP "${topdir}"/launch_gapi_test_app.sh "${board_user}@[${board_ip}]:/tmp/GAPI-tests/launch_gapi_test_app.sh" 1>/dev/null || {
+	transfer_launch_gapi_tests_script "${board_ip}" "${board_user}" "${board_password}" "${topdir}" || {
 		echo -e "${RED}Error:${ENDCOLOR} Failed to transfer API test launch script to board"
 		exit 1
 	}

--- a/src/launch_gapi_conformance_tests.sh
+++ b/src/launch_gapi_conformance_tests.sh
@@ -91,7 +91,7 @@ connect_and_transfer_gapi_with_ssh() {
 
 	echo ""
 	echo "Cleaning previous test results on board"
-	cleanup_api_ssh "${board_ip}" "${board_user}" "${board_password}"
+	cleanup_api_ssh "${board_ip}" "${board_user}" "${board_password}" "${topdir}"
 
 	SSH mkdir -p /tmp/GAPI-tests/{upper,work,base,app,rootfs} || {
 		echo -e "${RED}Error:${ENDCOLOR} Failed to create test directory on board"
@@ -157,27 +157,21 @@ cleanup_api_ssh() {
 	local board_ip="$1"
 	local board_user="$2"
 	local board_password="$3"
+	local topdir="$4"
 
 	echo ""
 	echo "Cleaning up test files on board"
-	if SSH mountpoint -q /tmp/GAPI-tests/rootfs; then
-		SSH "umount /tmp/GAPI-tests/rootfs" || {
-			echo -e "${RED}Error:${ENDCOLOR} Failed to unmount test filesystem on board"
-			exit 1
-		}
-	fi
-	if SSH mountpoint -q /tmp/GAPI-tests/base; then
-		SSH "umount /tmp/GAPI-tests/base" || {
-			echo -e "${RED}Error:${ENDCOLOR} Failed to unmount base filesystem on board"
-			exit 1
-		}
-	fi
-	if SSH mountpoint -q /tmp/GAPI-tests/app; then
-		SSH "umount /tmp/GAPI-tests/app" || {
-			echo -e "${RED}Error:${ENDCOLOR} Failed to unmount app filesystem on board"
-			exit 1
-		}
-	fi
+
+	transfer_launch_gapi_tests_script "${board_ip}" "${board_user}" "${board_password}" "${topdir}" || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to transfer API test launch script to board"
+		exit 1
+	}
+
+	SSH "chmod +x /tmp/GAPI-tests/launch_gapi_test_app.sh && /tmp/GAPI-tests/launch_gapi_test_app.sh clean" || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to clean up test files on board"
+		exit 1
+	}
+
 	SSH "rm -rf /tmp/GAPI-tests" || {
 		echo -e "${RED}Error:${ENDCOLOR} Failed to clean up test files on board"
 		exit 1

--- a/src/launch_gapi_conformance_tests.sh
+++ b/src/launch_gapi_conformance_tests.sh
@@ -8,8 +8,6 @@
 
 RED="\e[31m"
 ENDCOLOR="\e[0m"
-CONTAINER_ENGINE="lxc-execute"
-LXC_ARGS="-f /etc/lxc/default.conf -s lxc.uts.name=GAPI-tests -s lxc.rootfs.path=dir:/tmp/GAPI-tests/rootfs --share-net 1"
 declare CONFORMANCE_SSH_ARGS
 declare CONFORMANCE_SCP_ARGS
 
@@ -86,65 +84,26 @@ connect_and_transfer_gapi_with_ssh() {
 
 }
 
-verify_container_engine_on_board() {
-	local board_ip="$1"
-	local board_user="$2"
-	local board_password="$3"
-
-	for container_engine in ${CONTAINER_ENGINE}; do
-		SSH command -v "${container_engine}" 1>/dev/null 2>&1 && {
-			echo "${container_engine}"
-			return 0
-		}
-	done
-}
-
-mount_overlayfs_on_board() {
-	local board_ip="$1"
-	local board_user="$2"
-	local board_password="$3"
-
-	echo ""
-	echo "Mounting overlay filesystem on board"
-
-	SSH mount -t squashfs -o loop /etc/geisa/*.squashfs /tmp/GAPI-tests/base || {
-		echo -e "${RED}Error:${ENDCOLOR} Failed to mount base filesystem on board"
-		exit 1
-	}
-	SSH mount -t squashfs -o loop /tmp/GAPI-tests/gapi-conformance-tests.squashfs /tmp/GAPI-tests/app || {
-		echo -e "${RED}Error:${ENDCOLOR} Failed to mount app filesystem on board"
-		exit 1
-	}
-	SSH mount -t overlay overlay -o lowerdir=/tmp/GAPI-tests/base:/tmp/GAPI-tests/app,upperdir=/tmp/GAPI-tests/upper,workdir=/tmp/GAPI-tests/work /tmp/GAPI-tests/rootfs || {
-		echo -e "${RED}Error:${ENDCOLOR} Failed to mount overlay filesystem on board"
-		exit 1
-	}
-}
-
 launch_gapi_tests_with_report() {
 	local board_ip="$1"
 	local board_user="$2"
 	local board_password="$3"
 	local topdir="$4"
-	local container_engine=""
 
 	echo ""
 	echo "Launching tests..."
 
-	echo ""
-	echo "Verifying container engine on board"
-
-	container_engine=$(verify_container_engine_on_board "${board_ip}" "${board_user}" "${board_password}")
-
-	if [[ -z "${container_engine}" ]]; then
-		echo -e "${RED}Error:${ENDCOLOR} No container engine found on board between ${CONTAINER_ENGINE}"
+	if [[ ! -f "${topdir}"/launch_gapi_test_app.sh ]]; then
+		echo -e "${RED}Error:${ENDCOLOR} No API launching script found. Create a launch_gapi_test_app.sh script (see launch_gapi_test_app.sh.template or read the README)"
 		exit 1
 	fi
-	echo "Using ${container_engine} as container engine on board"
 
-	mount_overlayfs_on_board "${board_ip}" "${board_user}" "${board_password}"
+	SCP "${topdir}"/launch_gapi_test_app.sh "${board_user}@[${board_ip}]:/tmp/GAPI-tests/launch_gapi_test_app.sh" 1>/dev/null || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to transfer API test launch script to board"
+		exit 1
+	}
 
-	SSH "${container_engine}" "${LXC_ARGS}" -n GAPI-tests -- /etc/cukinia/cukinia -f junitxml -o /geisa-api-conformance-report.xml /etc/GEISA-API-tests/cukinia.conf
+	SSH "chmod +x /tmp/GAPI-tests/launch_gapi_test_app.sh && /tmp/GAPI-tests/launch_gapi_test_app.sh report"
 	api_test_exit_code=$?
 
 	echo ""
@@ -161,26 +120,22 @@ launch_gapi_tests_without_report() {
 	local board_ip="$1"
 	local board_user="$2"
 	local board_password="$3"
-	local container_engine=""
+	local topdir="$4"
 
 	echo ""
 	echo "Launching tests..."
 
-	echo ""
-	echo "Verifying container engine on board"
-
-	container_engine=$(verify_container_engine_on_board "${board_ip}" "${board_user}" "${board_password}")
-
-	if [[ -z "${container_engine}" ]]; then
-		echo -e "${RED}Error:${ENDCOLOR} No container engine found on board between ${CONTAINER_ENGINE}"
+	if [[ ! -f "${topdir}"/launch_gapi_test_app.sh ]]; then
+		echo -e "${RED}Error:${ENDCOLOR} No API launching script found. Create a launch_gapi_test_app.sh script (see launch_gapi_test_app.sh.template or read the README)"
 		exit 1
 	fi
-	echo "Using ${container_engine} as container engine on board"
 
+	SCP "${topdir}"/launch_gapi_test_app.sh "${board_user}@[${board_ip}]:/tmp/GAPI-tests/launch_gapi_test_app.sh" 1>/dev/null || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to transfer API test launch script to board"
+		exit 1
+	}
 
-	mount_overlayfs_on_board "${board_ip}" "${board_user}" "${board_password}"
-
-	SSH "${container_engine}" "${LXC_ARGS}" -n GAPI-tests -- /etc/cukinia/cukinia /etc/GEISA-API-tests/cukinia.conf
+	SSH "chmod +x /tmp/GAPI-tests/launch_gapi_test_app.sh && /tmp/GAPI-tests/launch_gapi_test_app.sh no-report"
 	api_test_exit_code=$?
 
 	export api_test_exit_code
@@ -190,7 +145,6 @@ cleanup_api_ssh() {
 	local board_ip="$1"
 	local board_user="$2"
 	local board_password="$3"
-	local container_engine=""
 
 	echo ""
 	echo "Cleaning up test files on board"


### PR DESCRIPTION
This pull request adds a more generic way of launching the API tests. As the specification are not specifying the way of launching the specifications, the conformance test users need to provide a script capable of launching the conformance API test application depending on their architecture