### PR TITLE
GEISA-API-tests: add GEISA instantaneous message tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ UseTab: Always
 BreakBeforeBraces: Linux
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
+BreakStringLiterals: false

--- a/src/GEISA-API-tests/src/Makefile
+++ b/src/GEISA-API-tests/src/Makefile
@@ -27,6 +27,8 @@ schemas: $(PB_C)
 $(BUILDIR)/schemas/%.pb.o: $(BUILDIR)/schemas/%.pb.c | build_dir
 	$(CC) $(CFLAGS) -c $< -o $@
 
+gapi_mosquitto.o gapi_discovery_common.o $(PB_C:.c=.o) $(NANOPB_CORE:.c=.o): | schemas
+
 $(objects): %: %.c gapi_mosquitto.o $(PB_C:.c=.o) $(NANOPB_CORE:.c=.o)
 
 install: $(objects)

--- a/src/GEISA-API-tests/src/Makefile
+++ b/src/GEISA-API-tests/src/Makefile
@@ -29,7 +29,7 @@ $(BUILDIR)/schemas/%.pb.o: $(BUILDIR)/schemas/%.pb.c | build_dir
 
 gapi_mosquitto.o gapi_discovery_common.o $(PB_C:.c=.o) $(NANOPB_CORE:.c=.o): | schemas
 
-$(objects): %: %.c gapi_mosquitto.o $(PB_C:.c=.o) $(NANOPB_CORE:.c=.o)
+$(objects): %: %.c gapi_mosquitto.o gapi_discovery_common.o $(PB_C:.c=.o) $(NANOPB_CORE:.c=.o)
 
 install: $(objects)
 	install -D -m 755 $(objects) $(DESTDIR)

--- a/src/GEISA-API-tests/src/Makefile
+++ b/src/GEISA-API-tests/src/Makefile
@@ -6,7 +6,7 @@ BUILDIR ?= build
 PROTOS := $(wildcard schemas/*.proto)
 PB_C := $(PROTOS:schemas/%.proto=$(BUILDIR)/schemas/%.pb.c)
 
-objects = gapi_connection gapi_discovery
+objects = gapi_connection gapi_discovery gapi_instantaneous
 all: schemas $(objects)
 
 DESTDIR ?= /usr/local/bin

--- a/src/GEISA-API-tests/src/gapi_connection.c
+++ b/src/GEISA-API-tests/src/gapi_connection.c
@@ -9,6 +9,13 @@ volatile bool running = true;
 volatile bool isConnected = false;
 volatile bool rr_disconnect = false;
 
+/**
+ * @brief Main function for the connection API test. It initializes the MQTT
+ * client, attempts to connect to the broker, and then deinitializes the client.
+ *
+ * @return EXIT_SUCCESS if the connection and disconnection were successful,
+ * otherwise EXIT_FAILURE.
+ */
 int main()
 {
 	struct mosquitto *mosq = NULL;

--- a/src/GEISA-API-tests/src/gapi_discovery.c
+++ b/src/GEISA-API-tests/src/gapi_discovery.c
@@ -3,11 +3,10 @@
  * @brief Test discovery API messages
  * @copyright Copyright (C) 2026 Southern California Edison
  */
-#include "gapi_mosquitto.h"
+#include "gapi_discovery.h"
 #include "pb.h"
 #include "pb_decode.h"
 #include "pb_encode.h"
-#include "schemas/discovery.pb.h"
 
 volatile bool running = true;
 volatile bool isConnected = false;
@@ -604,15 +603,9 @@ disconnect:
 
 int main(int argc, char *argv[])
 {
-	GeisaPlatformDiscovery_Req request =
-	    GeisaPlatformDiscovery_Req_init_default;
 	struct mosquitto *mosq = NULL;
-	uint8_t *message = NULL;
-	size_t encoded_size = 0;
-	pb_ostream_t ostream;
 	int return_code = 0;
 	int test_result = 0;
-	bool status = false;
 
 	if (argc != 2) {
 		fprintf(stderr, "Usage: %s <callback_type>\n", argv[0]);
@@ -677,39 +670,7 @@ int main(int argc, char *argv[])
 		goto disconnect;
 	}
 
-	status = pb_get_encoded_size(
-	    &encoded_size, GeisaPlatformDiscovery_Req_fields, &request);
-	if (!status) {
-		fprintf(stderr, "[Discovery] Error calculating encoded size for"
-				"platform discovery request\n");
-		return_code = EXIT_FAILURE;
-		goto disconnect;
-	}
-
-	message = malloc(encoded_size);
-	if (message == NULL) {
-		fprintf(stderr, "[Discovery] Error allocating memory for "
-				"platform discovery request\n");
-		return_code = EXIT_FAILURE;
-		goto disconnect;
-	}
-	ostream = pb_ostream_from_buffer(message, encoded_size);
-	status =
-	    pb_encode(&ostream, GeisaPlatformDiscovery_Req_fields, &request);
-	if (!status) {
-		fprintf(stderr, "[Discovery] Error encoding platform discovery "
-				"request\n");
-		return_code = EXIT_FAILURE;
-		free(message);
-		goto disconnect;
-	}
-	return_code = api_request_response(
-	    mosq, "geisa/api/platform/discovery/req/gapi-conformance-tests",
-	    encoded_size, message,
-	    "geisa/api/platform/discovery/rsp/gapi-conformance-tests", 1);
-
-	free(message);
-	pb_release(GeisaPlatformDiscovery_Req_fields, &request);
+	return_code = send_discovery_request(mosq);
 
 disconnect:
 	api_communication_deinit(mosq);

--- a/src/GEISA-API-tests/src/gapi_discovery.c
+++ b/src/GEISA-API-tests/src/gapi_discovery.c
@@ -46,9 +46,9 @@ static void check_geisa_status_message(struct mosquitto *mosq, void *obj,
 	}
 
 	if (response.has_status == false) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing status message\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing status message\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
@@ -61,9 +61,9 @@ static void check_geisa_status_message(struct mosquitto *mosq, void *obj,
 	}
 
 	if (!response.status.message || !response.status.message[0]) {
-		fprintf(stderr,
-			"[Discovery] Error: geisa status response missing "
-			"message information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: geisa status response missing message information\n");
 		*test_result = EXIT_FAILURE;
 	}
 
@@ -99,24 +99,25 @@ static void check_discovery_geisa_message(struct mosquitto *mosq, void *obj,
 	    pb_decode(&istream, GeisaPlatformDiscovery_Rsp_fields, &response);
 
 	if (!status) {
-		fprintf(stderr, "[Discovery] Error decoding platform "
-				"discovery response\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error decoding platform discovery response\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
 	if (response.has_geisa == false) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing geisa message\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing geisa message\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
 	if (response.geisa.pillar_api == false) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing pillar api could not be false\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing pillar api could not be false\n");
 		*test_result = EXIT_FAILURE;
 	}
 
@@ -138,37 +139,37 @@ static void check_device_top_module(GeisaPlatformDiscovery_Module top_module,
 				    int *test_result)
 {
 	if (!top_module.manufacturer[0]) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing top module manufacturer information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing top module manufacturer information\n");
 		*test_result = EXIT_FAILURE;
 	}
 
 	if (!top_module.model[0]) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing top module model information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing top module model information\n");
 		*test_result = EXIT_FAILURE;
 	}
 
 	if (!top_module.serial_number[0]) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing top module serial number information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing top module serial number information\n");
 		*test_result = EXIT_FAILURE;
 	}
 
 	if (!top_module.hw_revision[0]) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing top module hardware revision information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing top module hardware revision information\n");
 		*test_result = EXIT_FAILURE;
 	}
 
 	if (!top_module.fw_revision[0]) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing top module firmware revision information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing top module firmware revision information\n");
 		*test_result = EXIT_FAILURE;
 	}
 }
@@ -190,9 +191,9 @@ static void check_device_sub_modules(GeisaPlatformDiscovery_Module *sub_module,
 	}
 
 	if (sub_module == NULL) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing sub module information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing sub module information\n");
 		*test_result = EXIT_FAILURE;
 		return;
 	}
@@ -202,45 +203,35 @@ static void check_device_sub_modules(GeisaPlatformDiscovery_Module *sub_module,
 		if (!sub_module[loop_index].manufacturer[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing sub module number %ld manufacturer "
-			    "information\n",
+			    "[Discovery] Error: platform discovery response missing sub module number %ld manufacturer information\n",
 			    loop_index);
 			*test_result = EXIT_FAILURE;
 		}
 		if (!sub_module[loop_index].model[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing sub module number %ld model "
-			    "information\n",
+			    "[Discovery] Error: platform discovery response missing sub module number %ld model information\n",
 			    loop_index);
 			*test_result = EXIT_FAILURE;
 		}
 		if (!sub_module[loop_index].serial_number[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing sub module number %ld serial number "
-			    "information\n",
+			    "[Discovery] Error: platform discovery response missing sub module number %ld serial number information\n",
 			    loop_index);
 			*test_result = EXIT_FAILURE;
 		}
 		if (!sub_module[loop_index].hw_revision[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing sub module number %ld hardware "
-			    "revision information\n",
+			    "[Discovery] Error: platform discovery response missing sub module number %ld hardware revision information\n",
 			    loop_index);
 			*test_result = EXIT_FAILURE;
 		}
 		if (!sub_module[loop_index].fw_revision[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing sub module number %ld firmware "
-			    "revision information\n",
+			    "[Discovery] Error: platform discovery response missing sub module number %ld firmware revision information\n",
 			    loop_index);
 			*test_result = EXIT_FAILURE;
 		}
@@ -275,24 +266,25 @@ static void check_discovery_device_message(struct mosquitto *mosq, void *obj,
 	    pb_decode(&istream, GeisaPlatformDiscovery_Rsp_fields, &response);
 
 	if (!status) {
-		fprintf(stderr, "[Discovery] Error decoding platform "
-				"discovery response\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error decoding platform discovery response\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
 	if (response.has_device == false) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing device message\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing device message\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
 	if (response.device.has_top_module == false) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing device top module information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing device top module information\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
@@ -337,30 +329,31 @@ check_discovery_operator_message(struct mosquitto *mosq, void *obj,
 	    pb_decode(&istream, GeisaPlatformDiscovery_Rsp_fields, &response);
 
 	if (!status) {
-		fprintf(stderr, "[Discovery] Error decoding platform "
-				"discovery response\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error decoding platform discovery response\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
 	if (response.has_operator == false) {
-		fprintf(stdout,
-			"[Discovery] Info: platform discovery response "
-			"not provisioning optional operator information\n");
+		fprintf(
+		    stdout,
+		    "[Discovery] Info: platform discovery response not provisioning optional operator information\n");
 		goto disconnect;
 	}
 
 	if (!response.operator.operator_name[0]) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing operator name information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing operator name information\n");
 		*test_result = EXIT_FAILURE;
 	}
 
 	if (!response.operator.operator_identifier[0]) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing operator identifier information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing operator identifier information\n");
 		*test_result = EXIT_FAILURE;
 	}
 
@@ -399,8 +392,9 @@ check_discovery_metrology_geisa_message(struct mosquitto *mosq, void *obj,
 	    pb_decode(&istream, GeisaPlatformDiscovery_Rsp_fields, &response);
 
 	if (!status) {
-		fprintf(stderr, "[Discovery] Error decoding platform "
-				"discovery response\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error decoding platform discovery response\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
@@ -410,9 +404,7 @@ check_discovery_metrology_geisa_message(struct mosquitto *mosq, void *obj,
 		if (response.has_metrology == false) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing metrology information (Required for Meter "
-			    "type devices)\n");
+			    "[Discovery] Error: platform discovery response missing metrology information (Required for Meter type devices)\n");
 			*test_result = EXIT_FAILURE;
 			goto disconnect;
 		}
@@ -420,16 +412,14 @@ check_discovery_metrology_geisa_message(struct mosquitto *mosq, void *obj,
 		if (!response.metrology.meter_rating_class[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing meter rating class information\n");
+			    "[Discovery] Error: platform discovery response missing meter rating class information\n");
 			*test_result = EXIT_FAILURE;
 		}
 
 		if (!response.metrology.meter_form[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing meter form information\n");
+			    "[Discovery] Error: platform discovery response missing meter form information\n");
 			*test_result = EXIT_FAILURE;
 		}
 	}
@@ -468,17 +458,18 @@ static void check_discovery_sensor_message(struct mosquitto *mosq, void *obj,
 	    pb_decode(&istream, GeisaPlatformDiscovery_Rsp_fields, &response);
 
 	if (!status) {
-		fprintf(stderr, "[Discovery] Error decoding platform "
-				"discovery response\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error decoding platform discovery response\n");
 		*test_result = EXIT_FAILURE;
 		rr_disconnect = true;
 		goto disconnect;
 	}
 
 	if (response.has_sensor == false) {
-		fprintf(stdout,
-			"[Discovery] Info: platform discovery response "
-			"not provisioning optional sensor information\n");
+		fprintf(
+		    stdout,
+		    "[Discovery] Info: platform discovery response not provisioning optional sensor information\n");
 		goto disconnect;
 	}
 
@@ -487,9 +478,9 @@ static void check_discovery_sensor_message(struct mosquitto *mosq, void *obj,
 	}
 
 	if (response.sensor.sensors == NULL) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing sensors information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing sensors information\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
@@ -500,9 +491,7 @@ static void check_discovery_sensor_message(struct mosquitto *mosq, void *obj,
 		if (!response.sensor.sensors[loop_index].sensor_id[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing sensor number %ld sensor_id "
-			    "information\n",
+			    "[Discovery] Error: platform discovery response missing sensor number %ld sensor_id information\n",
 			    loop_index);
 			*test_result = EXIT_FAILURE;
 		}
@@ -510,8 +499,7 @@ static void check_discovery_sensor_message(struct mosquitto *mosq, void *obj,
 		if (!response.sensor.sensors[loop_index].unit[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing sensor number %ld unit information\n",
+			    "[Discovery] Error: platform discovery response missing sensor number %ld unit information\n",
 			    loop_index);
 			*test_result = EXIT_FAILURE;
 		}
@@ -520,11 +508,10 @@ static void check_discovery_sensor_message(struct mosquitto *mosq, void *obj,
 		    GeisaSensorType_GEISA_SENSOR_TYPE_CUSTOM) {
 			if (!response.sensor.sensors[loop_index]
 				 .custom_sensor_type[0]) {
-				fprintf(stderr,
-					"[Discovery] Error: platform discovery "
-					"response missing sensor number %ld "
-					"custom sensor type information\n",
-					loop_index);
+				fprintf(
+				    stderr,
+				    "[Discovery] Error: platform discovery response missing sensor number %ld custom sensor type information\n",
+				    loop_index);
 				*test_result = EXIT_FAILURE;
 			}
 		}
@@ -564,16 +551,17 @@ static void check_discovery_network_message(struct mosquitto *mosq, void *obj,
 	    pb_decode(&istream, GeisaPlatformDiscovery_Rsp_fields, &response);
 
 	if (!status) {
-		fprintf(stderr, "[Discovery] Error decoding platform "
-				"discovery response\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error decoding platform discovery response\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
 	if (response.has_network == false) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing network information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing network information\n");
 		*test_result = EXIT_FAILURE;
 	}
 
@@ -582,9 +570,9 @@ static void check_discovery_network_message(struct mosquitto *mosq, void *obj,
 	}
 
 	if (response.network.interfaces == NULL) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing network interfaces information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing network interfaces information\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
@@ -595,9 +583,7 @@ static void check_discovery_network_message(struct mosquitto *mosq, void *obj,
 		if (!response.network.interfaces[loop_index].interface_id[0]) {
 			fprintf(
 			    stderr,
-			    "[Discovery] Error: platform discovery response "
-			    "missing network interface number %ld "
-			    "interface_id information\n",
+			    "[Discovery] Error: platform discovery response missing network interface number %ld interface_id information\n",
 			    loop_index);
 			*test_result = EXIT_FAILURE;
 		}
@@ -638,25 +624,26 @@ check_discovery_waveform_message(struct mosquitto *mosq, void *obj,
 	    pb_decode(&istream, GeisaPlatformDiscovery_Rsp_fields, &response);
 
 	if (!status) {
-		fprintf(stderr, "[Discovery] Error decoding platform "
-				"discovery response\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error decoding platform discovery response\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
 	if (response.has_waveform == false) {
-		fprintf(stderr,
-			"[Discovery] Error: platform discovery response "
-			"missing waveform information\n");
+		fprintf(
+		    stderr,
+		    "[Discovery] Error: platform discovery response missing waveform information\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
 	if (response.waveform.streams_count != 0) {
 		if (response.waveform.streams == NULL) {
-			fprintf(stderr, "[Discovery] Error: platform discovery "
-					"response missing waveform streams "
-					"information\n");
+			fprintf(
+			    stderr,
+			    "[Discovery] Error: platform discovery response missing waveform streams information\n");
 			*test_result = EXIT_FAILURE;
 			goto disconnect;
 		}
@@ -667,12 +654,10 @@ check_discovery_waveform_message(struct mosquitto *mosq, void *obj,
 		     loop_index++) {
 			if (!response.waveform.streams[loop_index]
 				 .stream_id[0]) {
-				fprintf(stderr,
-					"[Discovery] Error: platform discovery "
-					"response missing waveform instance "
-					"number %ld stream_id "
-					"information\n",
-					loop_index);
+				fprintf(
+				    stderr,
+				    "[Discovery] Error: platform discovery response missing waveform instance number %ld stream_id information\n",
+				    loop_index);
 				*test_result = EXIT_FAILURE;
 			}
 			uint32_t total_channel_count =
@@ -684,13 +669,10 @@ check_discovery_waveform_message(struct mosquitto *mosq, void *obj,
 			if (total_channel_count !=
 			    response.waveform.streams[loop_index]
 				.total_channel_count) {
-				fprintf(stderr,
-					"[Discovery] Error: platform discovery "
-					"response stream number %ld total "
-					"channel count does not equal sum of "
-					"voltage, current, and other channel "
-					"counts\n",
-					loop_index);
+				fprintf(
+				    stderr,
+				    "[Discovery] Error: platform discovery response stream number %ld total channel count does not equal sum of voltage, current, and other channel counts\n",
+				    loop_index);
 				*test_result = EXIT_FAILURE;
 			}
 		}

--- a/src/GEISA-API-tests/src/gapi_discovery.c
+++ b/src/GEISA-API-tests/src/gapi_discovery.c
@@ -12,6 +12,15 @@ volatile bool running = true;
 volatile bool isConnected = false;
 volatile bool rr_disconnect = false;
 
+/**
+ * @brief Callback for geisa status response message, checks for successful
+ * status code and presence of status message information
+ *
+ * @param mosq mosquitto instance pointer
+ * @param obj pointer to test result variable to set to failure if any checks
+ * fail
+ * @param msg pointer to mosquitto message containing geisa status response
+ */
 static void check_geisa_status_message(struct mosquitto *mosq, void *obj,
 				       const struct mosquitto_message *msg)
 {
@@ -64,6 +73,15 @@ disconnect:
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Callback for geisa information response message, checks for presence
+ * of geisa information and pillar api support
+ *
+ * @param mosq mosquitto instance pointer
+ * @param obj pointer to test result variable to set to failure if any checks
+ * fail
+ * @param msg pointer to mosquitto message containing geisa information response
+ */
 static void check_discovery_geisa_message(struct mosquitto *mosq, void *obj,
 					  const struct mosquitto_message *msg)
 {
@@ -108,6 +126,14 @@ disconnect:
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Checks the top module information in the device message of the
+ * platform discovery response
+ *
+ * @param top_module The top module information to check
+ * @param test_result Pointer to the test result variable to set to failure if
+ * any checks fail
+ */
 static void check_device_top_module(GeisaPlatformDiscovery_Module top_module,
 				    int *test_result)
 {
@@ -147,6 +173,15 @@ static void check_device_top_module(GeisaPlatformDiscovery_Module top_module,
 	}
 }
 
+/**
+ * @brief Checks the sub module information in the device message of the
+ * platform discovery response
+ *
+ * @param sub_module The array of sub module information to check
+ * @param sub_module_count The number of sub modules in the array
+ * @param test_result Pointer to the test result variable to set to failure if
+ * any checks fail
+ */
 static void check_device_sub_modules(GeisaPlatformDiscovery_Module *sub_module,
 				     size_t sub_module_count, int *test_result)
 {
@@ -212,6 +247,17 @@ static void check_device_sub_modules(GeisaPlatformDiscovery_Module *sub_module,
 	}
 }
 
+/**
+ * @brief Callback for device information response message, checks for presence
+ * of device information and validates required fields in top module and sub
+ * modules
+ *
+ * @param mosq mosquitto instance pointer
+ * @param obj pointer to test result variable to set to failure if any checks
+ * fail
+ * @param msg pointer to mosquitto message containing device information
+ * response
+ */
 static void check_discovery_device_message(struct mosquitto *mosq, void *obj,
 					   const struct mosquitto_message *msg)
 {
@@ -262,6 +308,17 @@ disconnect:
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Callback for operator information response message, checks for
+ * presence of operator information and validates required fields if operator
+ * information is present
+ *
+ * @param mosq mosquitto instance pointer
+ * @param obj pointer to test result variable to set to failure if any checks
+ * fail
+ * @param msg pointer to mosquitto message containing operator information
+ * response
+ */
 static void
 check_discovery_operator_message(struct mosquitto *mosq, void *obj,
 				 const struct mosquitto_message *msg)
@@ -313,6 +370,17 @@ disconnect:
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Callback for metrology information response message, checks for
+ * presence of metrology information if device type is electric meter and
+ * validates required fields if metrology information is present
+ *
+ * @param mosq mosquitto instance pointer
+ * @param obj pointer to test result variable to set to failure if any checks
+ * fail
+ * @param msg pointer to mosquitto message containing metrology information
+ * response
+ */
 static void
 check_discovery_metrology_geisa_message(struct mosquitto *mosq, void *obj,
 					const struct mosquitto_message *msg)
@@ -372,6 +440,17 @@ disconnect:
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Callback for sensor information response message, checks for presence
+ * of sensor information and validates required fields if sensor information is
+ * present
+ *
+ * @param mosq mosquitto instance pointer
+ * @param obj pointer to test result variable to set to failure if any checks
+ * fail
+ * @param msg pointer to mosquitto message containing sensor information
+ * response
+ */
 static void check_discovery_sensor_message(struct mosquitto *mosq, void *obj,
 					   const struct mosquitto_message *msg)
 {
@@ -457,6 +536,17 @@ disconnect:
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Callback for network information response message, checks for presence
+ * of network information and validates required fields if network information
+ * is present
+ *
+ * @param mosq mosquitto instance pointer
+ * @param obj pointer to test result variable to set to failure if any checks
+ * fail
+ * @param msg pointer to mosquitto message containing network information
+ * response
+ */
 static void check_discovery_network_message(struct mosquitto *mosq, void *obj,
 					    const struct mosquitto_message *msg)
 {
@@ -519,6 +609,17 @@ disconnect:
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Callback for waveform information response message, checks for
+ * presence of waveform information and validates required fields if waveform
+ * information is present
+ *
+ * @param mosq mosquitto instance pointer
+ * @param obj pointer to test result variable to set to failure if any checks
+ * fail
+ * @param msg pointer to mosquitto message containing waveform information
+ * response
+ */
 static void
 check_discovery_waveform_message(struct mosquitto *mosq, void *obj,
 				 const struct mosquitto_message *msg)
@@ -601,6 +702,17 @@ disconnect:
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Main function for discovery API tests, initializes MQTT communication,
+ * sets appropriate message callback based on command line argument, sends
+ * discovery request, and processes responses until test completion or failure
+ *
+ * @param argc Argument count from command line
+ * @param argv Argument vector from command line, expects one argument
+ * specifying the callback type to test
+ * @return EXIT_SUCCESS if all tests pass, EXIT_FAILURE if any test fails or if
+ * there is an error in setup
+ */
 int main(int argc, char *argv[])
 {
 	struct mosquitto *mosq = NULL;

--- a/src/GEISA-API-tests/src/gapi_discovery.h
+++ b/src/GEISA-API-tests/src/gapi_discovery.h
@@ -1,0 +1,21 @@
+/**
+ * @file gapi_discovery.h
+ * @brief Header file for API platform discovery messages
+ * @copyright Copyright (C) 2026 Southern California Edison
+ */
+
+#ifndef GAPI_DISCOVERY_H
+#define GAPI_DISCOVERY_H
+
+#include "gapi_mosquitto.h"
+#include "schemas/discovery.pb.h"
+
+/**
+ * @brief Send a discovery request message to the MQTT broker
+ *
+ * @param mosq Pointer to the Mosquitto client instance
+ * @return 0 on success, non-zero on failure
+ */
+int send_discovery_request(struct mosquitto *mosq);
+
+#endif // GAPI_DISCOVERY_H

--- a/src/GEISA-API-tests/src/gapi_discovery_common.c
+++ b/src/GEISA-API-tests/src/gapi_discovery_common.c
@@ -1,0 +1,63 @@
+/**
+ * @file gapi_discovery_common.c
+ * @brief Definitions for common functions for GAPI tests
+ * @copyright Copyright (C) 2026 Southern California Edison
+ */
+#include "gapi_discovery.h"
+#include "pb.h"
+#include "pb_decode.h"
+#include "pb_encode.h"
+
+/**
+ * @brief Send a platform discovery request and wait for the response
+ *
+ * @param mosq The MQTT client instance to use for sending the request
+ * @return int EXIT_SUCCESS if the request was sent and the response was
+ * received successfully, EXIT_FAILURE if there was an error sending the request
+ * or receiving the response
+ */
+int send_discovery_request(struct mosquitto *mosq)
+{
+	GeisaPlatformDiscovery_Req request =
+	    GeisaPlatformDiscovery_Req_init_default;
+	uint8_t *message = NULL;
+	size_t encoded_size = 0;
+	pb_ostream_t ostream;
+	bool status = false;
+	int return_code = 0;
+
+	status = pb_get_encoded_size(
+	    &encoded_size, GeisaPlatformDiscovery_Req_fields, &request);
+	if (!status) {
+		fprintf(
+		    stderr,
+		    "[Discovery] Error calculating encoded size for platform discovery request\n");
+		return EXIT_FAILURE;
+	}
+
+	message = malloc(encoded_size);
+	if (message == NULL) {
+		fprintf(
+		    stderr,
+		    "[Discovery] Error allocating memory for platform discovery request\n");
+		return EXIT_FAILURE;
+	}
+	ostream = pb_ostream_from_buffer(message, encoded_size);
+	status =
+	    pb_encode(&ostream, GeisaPlatformDiscovery_Req_fields, &request);
+	if (!status) {
+		fprintf(
+		    stderr,
+		    "[Discovery] Error encoding platform discovery request\n");
+		free(message);
+		return EXIT_FAILURE;
+	}
+	return_code = api_request_response(
+	    mosq, "geisa/api/platform/discovery/req/gapi-conformance-tests",
+	    encoded_size, message,
+	    "geisa/api/platform/discovery/rsp/gapi-conformance-tests", 1);
+
+	free(message);
+	pb_release(GeisaPlatformDiscovery_Req_fields, &request);
+	return return_code;
+}

--- a/src/GEISA-API-tests/src/gapi_instantaneous.c
+++ b/src/GEISA-API-tests/src/gapi_instantaneous.c
@@ -3,28 +3,166 @@
  * @brief Test instantaneous API messages
  * @copyright Copyright (C) 2026 Southern California Edison
  */
+
+#include "gapi_discovery.h"
 #include "gapi_mosquitto.h"
 #include "pb.h"
 #include "pb_decode.h"
 #include "pb_encode.h"
 #include "schemas/metered_quantities.pb.h"
+#include <stdbool.h>
 
 volatile bool running = true;
 volatile bool isConnected = false;
 volatile bool rr_disconnect = false;
 const int TIMEOUT_S = 5;
 
+/**
+ * @brief Context structure for the instantaneous test, used to store
+ * information about the device under test and the test result.
+ */
+struct instantaneous_test_ctx {
+	int test_result;
+	bool is_meter;
+	uint32_t phase_count;
+	bool neutral_connected;
+};
+
+/**
+ * @brief Callback function to get the discovery information of the device under
+ * test. This function decodes the discovery response and updates the context
+ * with information about the device.
+ *
+ * @param mosq The mosquitto client instance
+ * @param obj The user data object, which is a pointer to the instantaneous test
+ * context
+ * @param msg The MQTT message containing the discovery response
+ */
+static void get_discovery_information(struct mosquitto *mosq, void *obj,
+				      const struct mosquitto_message *msg)
+{
+	GeisaPlatformDiscovery_Rsp response =
+	    GeisaPlatformDiscovery_Rsp_init_default;
+	struct instantaneous_test_ctx *ctx = obj;
+	pb_istream_t istream;
+	bool status = false;
+	(void)mosq;
+
+	ctx->is_meter = false;
+	ctx->phase_count = 0;
+	ctx->neutral_connected = false;
+
+	istream = pb_istream_from_buffer(msg->payload, msg->payloadlen);
+	status =
+	    pb_decode(&istream, GeisaPlatformDiscovery_Rsp_fields, &response);
+
+	if (!status) {
+		fprintf(stderr,
+			"[Instantaneous] Error decoding discovery response\n");
+		ctx->test_result = EXIT_FAILURE;
+		goto disconnect;
+	}
+
+	if (response.has_metrology == false) {
+		goto disconnect;
+	}
+
+	if (response.device.top_module.type ==
+	    GeisaPlatformDiscovery_DeviceType_TYPE_ELECTRIC_METER) {
+		ctx->is_meter = true;
+		ctx->phase_count = response.metrology.phase_count;
+		ctx->neutral_connected = response.metrology.neutral_connected;
+	}
+
+disconnect:
+	pb_release(GeisaPlatformDiscovery_Rsp_fields, &response);
+	rr_disconnect = true;
+}
+
+/**
+ * @brief Function to check the instantaneous response for a meter. This
+ * function checks that the response contains the expected messages when the
+ * device is a meter.
+ *
+ * @param ctx The context of the instantaneous test, containing information
+ * about the device under test
+ * @param response The decoded instantaneous response from the meter
+ */
+static void
+check_meter_instantaneous_response(struct instantaneous_test_ctx *ctx,
+				   GeisaInstantaneousQuantities *response)
+{
+	if (ctx->phase_count == 1) {
+		if (response->has_phase_A == false) {
+			fprintf(
+			    stderr,
+			    "[Instantaneous] Error: single phase meter instantaneous response missing phase_A message\n");
+			ctx->test_result = EXIT_FAILURE;
+		}
+	} else if (ctx->phase_count == 2) {
+		if (response->has_phase_A == false) {
+			fprintf(
+			    stderr,
+			    "[Instantaneous] Error: two phase meter instantaneous response missing phase_A message\n");
+			ctx->test_result = EXIT_FAILURE;
+		}
+		if (response->has_phase_B == false) {
+			fprintf(
+			    stderr,
+			    "[Instantaneous] Error: two phase meter instantaneous response missing phase_B message\n");
+			ctx->test_result = EXIT_FAILURE;
+		}
+	} else if (ctx->phase_count == 3) {
+		if (response->has_phase_A == false) {
+			fprintf(
+			    stderr,
+			    "[Instantaneous] Error: three phase meter instantaneous response missing phase_A message\n");
+			ctx->test_result = EXIT_FAILURE;
+		}
+		if (response->has_phase_B == false) {
+			fprintf(
+			    stderr,
+			    "[Instantaneous] Error: three phase meter instantaneous response missing phase_B message\n");
+			ctx->test_result = EXIT_FAILURE;
+		}
+		if (response->has_phase_C == false) {
+			fprintf(
+			    stderr,
+			    "[Instantaneous] Error: three phase meter instantaneous response missing phase_C message\n");
+			ctx->test_result = EXIT_FAILURE;
+		}
+	}
+	if (ctx->neutral_connected) {
+		if (response->has_phase_N == false) {
+			fprintf(
+			    stderr,
+			    "[Instantaneous] Error: meter with neutral connected instantaneous response missing neutral message\n");
+			ctx->test_result = EXIT_FAILURE;
+		}
+	}
+}
+
+/**
+ * @brief Callback function to check the instantaneous response message. This
+ * function decodes the instantaneous response and checks that it contains the
+ * expected information based on the device type and discovery information.
+ *
+ * @param mosq The mosquitto client instance
+ * @param obj The user data object, which is a pointer to the instantaneous test
+ * context
+ * @param msg The MQTT message containing the instantaneous response
+ */
 static void check_instantaneous_message(struct mosquitto *mosq, void *obj,
 					const struct mosquitto_message *msg)
 {
 	GeisaInstantaneousQuantities response =
 	    GeisaInstantaneousQuantities_init_default;
 	(void)mosq;
-	int *test_result = obj;
+	struct instantaneous_test_ctx *ctx = obj;
 	pb_istream_t istream;
 	bool status = false;
 
-	*test_result = EXIT_SUCCESS;
+	ctx->test_result = EXIT_SUCCESS;
 
 	istream = pb_istream_from_buffer(msg->payload, msg->payloadlen);
 	status =
@@ -34,51 +172,50 @@ static void check_instantaneous_message(struct mosquitto *mosq, void *obj,
 		fprintf(
 		    stderr,
 		    "[Instantaneous] Error decoding instantaneous response\n");
-		*test_result = EXIT_FAILURE;
+		ctx->test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
-	if (response.has_phase_A == false) {
+	if (response.timestamp == 0) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
-				"missing phase_A message\n");
-		*test_result = EXIT_FAILURE;
+				"missing timestamp information\n");
+		ctx->test_result = EXIT_FAILURE;
 	}
 
-	if (response.has_phase_B == false) {
-		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
-				"missing phase_B message\n");
-		*test_result = EXIT_FAILURE;
+	if (ctx->is_meter) {
+		check_meter_instantaneous_response(ctx, &response);
 	}
 
-	if (response.has_phase_C == false) {
-		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
-				"missing phase_C message\n");
-		*test_result = EXIT_FAILURE;
-	}
-
-	if (response.has_phase_N == false) {
-		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
-				"missing phase_N message\n");
-		*test_result = EXIT_FAILURE;
-	}
 	if (response.has_other == false) {
-		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
-				"missing other message\n");
-		*test_result = EXIT_FAILURE;
+		fprintf(
+		    stderr,
+		    "[Instantaneous] Error: instantaneous response missing other message\n");
+		ctx->test_result = EXIT_FAILURE;
 	}
 
 disconnect:
 	pb_release(GeisaInstantaneousQuantities_fields, &response);
-	printf("[Instantaneous] test_result: %d\n", *test_result);
+	printf("[Instantaneous] test_result: %d\n", ctx->test_result);
 	running = false;
 }
 
+/**
+ * @brief Main function for the instantaneous API test. This function
+ * initializes the MQTT communication, sends a discovery request, and checks the
+ * instantaneous response messages.
+ *
+ * @return EXIT_SUCCESS if the test passes, EXIT_FAILURE if the test fails
+ */
 int main()
 {
 	struct mosquitto *mosq = NULL;
 	int return_code = 0;
-	int test_result = 0;
 	time_t start = 0;
+
+	struct instantaneous_test_ctx *ctx =
+	    calloc(1, sizeof(struct instantaneous_test_ctx));
+
+	ctx->test_result = 0;
 
 	mosq = api_communication_init();
 	if (!mosq) {
@@ -86,9 +223,7 @@ int main()
 		goto exit;
 	}
 
-	mosquitto_message_callback_set(mosq, check_instantaneous_message);
-
-	mosquitto_user_data_set(mosq, &test_result);
+	mosquitto_user_data_set(mosq, ctx);
 
 	start = time(NULL);
 	while (running && !isConnected) {
@@ -108,9 +243,22 @@ int main()
 		goto disconnect;
 	}
 
+	mosquitto_message_callback_set(mosq, get_discovery_information);
+	return_code = send_discovery_request(mosq);
+	if (return_code == EXIT_FAILURE) {
+		fprintf(stderr,
+			"[Instantaneous] Error sending discovery request\n");
+		goto disconnect;
+	}
+
+	// Set running back to true after sending the discovery request
+	running = true;
+
+	mosquitto_message_callback_set(mosq, check_instantaneous_message);
+
 	return_code = api_subscribe(mosq, "geisa/api/instantaneous/data", 0);
 	if (return_code != MOSQ_ERR_SUCCESS) {
-		fprintf(stderr, "[Discovery] Error subscribing to "
+		fprintf(stderr, "[Instantaneous] Error subscribing to "
 				"geisa/api/instantaneous/data topic\n");
 		return_code = EXIT_FAILURE;
 		goto disconnect;
@@ -130,5 +278,7 @@ int main()
 disconnect:
 	api_communication_deinit(mosq);
 exit:
-	return return_code || test_result;
+	return_code = return_code ? return_code : ctx->test_result;
+	free(ctx);
+	return return_code;
 }

--- a/src/GEISA-API-tests/src/gapi_instantaneous.c
+++ b/src/GEISA-API-tests/src/gapi_instantaneous.c
@@ -177,8 +177,9 @@ static void check_instantaneous_message(struct mosquitto *mosq, void *obj,
 	}
 
 	if (response.timestamp == 0) {
-		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
-				"missing timestamp information\n");
+		fprintf(
+		    stderr,
+		    "[Instantaneous] Error: instantaneous response missing timestamp information\n");
 		ctx->test_result = EXIT_FAILURE;
 	}
 
@@ -258,8 +259,9 @@ int main()
 
 	return_code = api_subscribe(mosq, "geisa/api/instantaneous/data", 0);
 	if (return_code != MOSQ_ERR_SUCCESS) {
-		fprintf(stderr, "[Instantaneous] Error subscribing to "
-				"geisa/api/instantaneous/data topic\n");
+		fprintf(
+		    stderr,
+		    "[Instantaneous] Error subscribing to geisa/api/instantaneous/data topic\n");
 		return_code = EXIT_FAILURE;
 		goto disconnect;
 	}

--- a/src/GEISA-API-tests/src/gapi_instantaneous.c
+++ b/src/GEISA-API-tests/src/gapi_instantaneous.c
@@ -42,34 +42,29 @@ static void check_instantaneous_message(struct mosquitto *mosq, void *obj,
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing phase_A message\n");
 		*test_result = EXIT_FAILURE;
-		goto disconnect;
 	}
 
 	if (response.has_phase_B == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing phase_B message\n");
 		*test_result = EXIT_FAILURE;
-		goto disconnect;
 	}
 
 	if (response.has_phase_C == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing phase_C message\n");
 		*test_result = EXIT_FAILURE;
-		goto disconnect;
 	}
 
 	if (response.has_phase_N == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing phase_N message\n");
 		*test_result = EXIT_FAILURE;
-		goto disconnect;
 	}
 	if (response.has_other == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing other message\n");
 		*test_result = EXIT_FAILURE;
-		goto disconnect;
 	}
 
 disconnect:

--- a/src/GEISA-API-tests/src/gapi_instantaneous.c
+++ b/src/GEISA-API-tests/src/gapi_instantaneous.c
@@ -1,0 +1,133 @@
+/**
+ * @file gapi_instantaneous.c
+ * @brief Test instantaneous API messages
+ * @copyright Copyright (C) 2026 Southern California Edison
+ */
+#include "gapi_mosquitto.h"
+#include "schemas/metered_quantities.pb-c.h"
+
+volatile bool running = true;
+volatile bool isConnected = false;
+volatile bool rr_disconnect = false;
+const int TIMEOUT_S = 5;
+
+static void check_instantaneous_message(struct mosquitto *mosq, void *obj,
+					const struct mosquitto_message *msg)
+{
+	GeisaInstantaneousQuantities *response = NULL;
+	(void)mosq;
+	int *test_result = obj;
+
+	*test_result = EXIT_SUCCESS;
+
+	response = geisa_instantaneous_quantities__unpack(
+	    NULL, msg->payloadlen, (uint8_t *)msg->payload);
+
+	if (response == NULL) {
+		fprintf(
+		    stderr,
+		    "[Instantaneous] Error unpacking instantaneous response\n");
+		*test_result = EXIT_FAILURE;
+		goto disconnect;
+	}
+
+	if (response->phase_a == NULL) {
+		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
+				"missing phase_A message\n");
+		*test_result = EXIT_FAILURE;
+		goto disconnect;
+	}
+
+	if (response->phase_b == NULL) {
+		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
+				"missing phase_B message\n");
+		*test_result = EXIT_FAILURE;
+		goto disconnect;
+	}
+
+	if (response->phase_c == NULL) {
+		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
+				"missing phase_C message\n");
+		*test_result = EXIT_FAILURE;
+		goto disconnect;
+	}
+
+	if (response->phase_n == NULL) {
+		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
+				"missing phase_N message\n");
+		*test_result = EXIT_FAILURE;
+		goto disconnect;
+	}
+	if (response->other == NULL) {
+		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
+				"missing other message\n");
+		*test_result = EXIT_FAILURE;
+		goto disconnect;
+	}
+
+disconnect:
+	geisa_instantaneous_quantities__free_unpacked(response, NULL);
+
+	printf("[Instantaneous] test_result: %d\n", *test_result);
+	running = false;
+}
+
+int main()
+{
+	struct mosquitto *mosq = NULL;
+	int return_code = 0;
+	int test_result = 0;
+	time_t start = 0;
+
+	mosq = api_communication_init();
+	if (!mosq) {
+		return_code = EXIT_FAILURE;
+		goto exit;
+	}
+
+	mosquitto_message_callback_set(mosq, check_instantaneous_message);
+
+	mosquitto_user_data_set(mosq, &test_result);
+
+	start = time(NULL);
+	while (running && !isConnected) {
+		mosquitto_loop(mosq, -1, 1);
+		if (difftime(time(NULL), start) > TIMEOUT_S) {
+			fprintf(stderr,
+				"Connection timed out after %d seconds\n",
+				TIMEOUT_S);
+			return_code = EXIT_FAILURE;
+			goto disconnect;
+		}
+	}
+
+	if (!isConnected) {
+		fprintf(stderr, "Failed to connect to broker\n");
+		return_code = EXIT_FAILURE;
+		goto disconnect;
+	}
+
+	return_code = api_subscribe(mosq, "geisa/api/instantaneous/data", 0);
+	if (return_code != MOSQ_ERR_SUCCESS) {
+		fprintf(stderr, "[Discovery] Error subscribing to "
+				"geisa/api/instantaneous/data topic\n");
+		return_code = EXIT_FAILURE;
+		goto disconnect;
+	}
+
+	start = time(NULL);
+	while (running) {
+		mosquitto_loop(mosq, -1, 1);
+		if (difftime(time(NULL), start) > TIMEOUT_S) {
+			fprintf(stderr, "Test timed out after %d seconds\n",
+				TIMEOUT_S);
+			return_code = EXIT_FAILURE;
+			goto disconnect;
+		}
+	}
+
+disconnect:
+	api_communication_deinit(mosq);
+exit:
+	return return_code || test_result;
+}

--- a/src/GEISA-API-tests/src/gapi_instantaneous.c
+++ b/src/GEISA-API-tests/src/gapi_instantaneous.c
@@ -4,7 +4,10 @@
  * @copyright Copyright (C) 2026 Southern California Edison
  */
 #include "gapi_mosquitto.h"
-#include "schemas/metered_quantities.pb-c.h"
+#include "pb.h"
+#include "pb_decode.h"
+#include "pb_encode.h"
+#include "schemas/metered_quantities.pb.h"
 
 volatile bool running = true;
 volatile bool isConnected = false;
@@ -14,51 +17,55 @@ const int TIMEOUT_S = 5;
 static void check_instantaneous_message(struct mosquitto *mosq, void *obj,
 					const struct mosquitto_message *msg)
 {
-	GeisaInstantaneousQuantities *response = NULL;
+	GeisaInstantaneousQuantities response =
+	    GeisaInstantaneousQuantities_init_default;
 	(void)mosq;
 	int *test_result = obj;
+	pb_istream_t istream;
+	bool status = false;
 
 	*test_result = EXIT_SUCCESS;
 
-	response = geisa_instantaneous_quantities__unpack(
-	    NULL, msg->payloadlen, (uint8_t *)msg->payload);
+	istream = pb_istream_from_buffer(msg->payload, msg->payloadlen);
+	status =
+	    pb_decode(&istream, GeisaInstantaneousQuantities_fields, &response);
 
-	if (response == NULL) {
+	if (!status) {
 		fprintf(
 		    stderr,
-		    "[Instantaneous] Error unpacking instantaneous response\n");
+		    "[Instantaneous] Error decoding instantaneous response\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
-	if (response->phase_a == NULL) {
+	if (response.has_phase_A == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing phase_A message\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
-	if (response->phase_b == NULL) {
+	if (response.has_phase_B == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing phase_B message\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
-	if (response->phase_c == NULL) {
+	if (response.has_phase_C == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing phase_C message\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
 
-	if (response->phase_n == NULL) {
+	if (response.has_phase_N == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing phase_N message\n");
 		*test_result = EXIT_FAILURE;
 		goto disconnect;
 	}
-	if (response->other == NULL) {
+	if (response.has_other == false) {
 		fprintf(stderr, "[Instantaneous] Error: instantaneous response "
 				"missing other message\n");
 		*test_result = EXIT_FAILURE;
@@ -66,8 +73,7 @@ static void check_instantaneous_message(struct mosquitto *mosq, void *obj,
 	}
 
 disconnect:
-	geisa_instantaneous_quantities__free_unpacked(response, NULL);
-
+	pb_release(GeisaInstantaneousQuantities_fields, &response);
 	printf("[Instantaneous] test_result: %d\n", *test_result);
 	running = false;
 }

--- a/src/GEISA-API-tests/src/gapi_mosquitto.c
+++ b/src/GEISA-API-tests/src/gapi_mosquitto.c
@@ -14,6 +14,11 @@ const int RR_TIMEOUT_S = 5;
 
 static int sent_mid;
 
+/**
+ * @brief Function to handle signals for graceful shutdown
+ *
+ * @param signal The signal number received
+ */
 static void handle_signal(int signal)
 {
 	fprintf(stderr, "Caught signal %d, disconnecting...\n", signal);
@@ -21,6 +26,13 @@ static void handle_signal(int signal)
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Callback function for connection to the MQTT broker
+ *
+ * @param mosq The mosquitto client instance
+ * @param obj User-defined data (not used in this implementation)
+ * @param return_code The return code from the connection attempt
+ */
 static void on_connect(struct mosquitto *mosq, void *obj, int return_code)
 {
 	(void)obj;
@@ -35,6 +47,13 @@ static void on_connect(struct mosquitto *mosq, void *obj, int return_code)
 	}
 }
 
+/**
+ * @brief Callback function for disconnection from the MQTT broker
+ *
+ * @param mosq The mosquitto client instance
+ * @param obj User-defined data (not used in this implementation)
+ * @param return_code The return code from the disconnection event
+ */
 static void on_disconnect(struct mosquitto *mosq, void *obj, int return_code)
 {
 	(void)obj;
@@ -43,6 +62,15 @@ static void on_disconnect(struct mosquitto *mosq, void *obj, int return_code)
 	isConnected = false;
 }
 
+/**
+ * @brief Callback function for message publication
+ * This function set the running flag to false when the published message is
+ * acknowledged by the broker, allowing the main loop to exit gracefully.
+ *
+ * @param mosq The mosquitto client instance
+ * @param obj User-defined data (not used in this implementation)
+ * @param mid The message ID of the published message
+ */
 static void on_publish(struct mosquitto *mosq, void *obj, int mid)
 {
 	(void)obj;
@@ -56,6 +84,16 @@ static void on_publish(struct mosquitto *mosq, void *obj, int mid)
 	}
 }
 
+/**
+ * @brief Callback function for incoming messages
+ * This function prints the topic and payload of the received message, and sets
+ * the rr_disconnect flag to true to indicate that a response has been received
+ * for a request-response operation.
+ *
+ * @param mosq The mosquitto client instance
+ * @param obj User-defined data (not used in this implementation)
+ * @param msg The received MQTT message
+ */
 static void on_message(struct mosquitto *mosq, void *obj,
 		       const struct mosquitto_message *msg)
 {
@@ -66,6 +104,19 @@ static void on_message(struct mosquitto *mosq, void *obj,
 	rr_disconnect = true;
 }
 
+/**
+ * @brief Reads MQTT configuration from a file and populates the mqtt_config
+ * structure
+ *
+ * The function reads the MQTT configuration parameters (HOST, PORT, USERID,
+ * PASSWORD) from the /etc/geisa/mqtt.conf file. Each line in the configuration
+ * file should be in the format "KEY=VALUE". The function parses each line and
+ * updates the corresponding fields in the mqtt_config structure.
+ *
+ * @param cfg Pointer to the mqtt_config structure to be populated with the
+ * configuration values
+ * @return 0 on success, -1 on failure (e.g., if the file cannot be opened)
+ */
 static int read_mqtt_conf_file(mqtt_config *cfg)
 {
 	FILE *file = fopen("/etc/geisa/mqtt.conf", "r");
@@ -101,6 +152,10 @@ static int read_mqtt_conf_file(mqtt_config *cfg)
 	return 0;
 }
 
+/**
+ * @brief Initializes the MQTT communication by reading the configuration,
+ * setting up the Mosquitto client, and connecting to the MQTT broker
+ */
 struct mosquitto *api_communication_init()
 {
 	struct mosquitto *mosq = NULL;
@@ -148,6 +203,12 @@ cleanup:
 	return NULL;
 }
 
+/**
+ * @brief Deinitializes the MQTT communication by disconnecting from the broker,
+ * destroying the Mosquitto client, and cleaning up the Mosquitto library
+ *
+ * @param mosq The mosquitto client instance to be deinitialized
+ */
 void api_communication_deinit(struct mosquitto *mosq)
 {
 	mosquitto_disconnect(mosq);
@@ -155,6 +216,14 @@ void api_communication_deinit(struct mosquitto *mosq)
 	mosquitto_lib_cleanup();
 }
 
+/**
+ * @brief Subscribes to a specified MQTT topic with a given QoS level
+ *
+ * @param mosq The mosquitto client instance
+ * @param topic The MQTT topic to subscribe to
+ * @param qos The Quality of Service level for the subscription (0, 1, or 2)
+ * @return 0 on success, or a non-zero error code on failure
+ */
 int api_subscribe(struct mosquitto *mosq, const char *topic, int qos)
 {
 	int return_code = 0;
@@ -169,6 +238,16 @@ int api_subscribe(struct mosquitto *mosq, const char *topic, int qos)
 	return 0;
 }
 
+/**
+ * @brief Publishes a message to a specified MQTT topic with a given QoS level
+ *
+ * @param mosq The mosquitto client instance
+ * @param topic The MQTT topic to publish to
+ * @param message_size The size of the message payload in bytes
+ * @param message The message payload as a byte array
+ * @param qos The Quality of Service level for the publication (0, 1, or 2)
+ * @return 0 on success, or a non-zero error code on failure
+ */
 int api_publish(struct mosquitto *mosq, const char *topic,
 		const size_t message_size, const uint8_t *message, int qos)
 {
@@ -185,6 +264,22 @@ int api_publish(struct mosquitto *mosq, const char *topic,
 	return 0;
 }
 
+/**
+ * @brief Performs a request-response operation by subscribing to a response
+ * topic, publishing a request message to a specified topic, and waiting for a
+ * response message or timeout
+ *
+ * @param mosq The mosquitto client instance
+ * @param topic The MQTT topic to publish the request message to
+ * @param message_size The size of the request message payload in bytes
+ * @param message The request message payload as a byte array
+ * @param response_topic The MQTT topic to subscribe to for receiving the
+ * response
+ * @param qos The Quality of Service level for both the subscription and
+ * publication (0, 1, or 2)
+ * @return 0 on success (response received), -1 on timeout, or a non-zero error
+ * code on failure
+ */
 int api_request_response(struct mosquitto *mosq, const char *topic,
 			 const size_t message_size, const uint8_t *message,
 			 const char *response_topic, int qos)

--- a/src/GEISA-API-tests/tests.d/03-api-instantaneous.conf
+++ b/src/GEISA-API-tests/tests.d/03-api-instantaneous.conf
@@ -1,0 +1,6 @@
+# Copyright (C) 2026 Southern California Edison
+
+logging suite "GEISA API - Test instantaneous messages"
+cukinia_log "$(_colorize blue "--- GEISA API - Test instantaneous messages ---")"
+
+as "Checking instantaneous messages" cukinia_cmd gapi_instantaneous


### PR DESCRIPTION
Add test for GEISA instantaneous messages. This test subscribes to the "geisa/api/instantaneous/data" topic and checks that the received message contains the expected fields.