### PR TITLE
GEISA-ADM-tests: add GEISA EMS-ADM tests

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -8,8 +8,11 @@ RUN set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         black \
+        bsdmainutils \
         clang-format \
         clang-tidy \
+        curl \
+        default-jre-headless \
         fuse-overlayfs \
         iperf3 \
         iputils-ping \
@@ -33,5 +36,5 @@ RUN set -x \
         uidmap \
     && rm -rf /var/lib/apt/lists/
 
-# Remove default dialout group alowing creating it with the host GID
+# Remove default dialout group allowing creating it with the host GID
 RUN groupdel dialout

--- a/.cqfdrc
+++ b/.cqfdrc
@@ -5,6 +5,7 @@ name='tests'
 [build]
 command='shellcheck -xo all launch_conformance_tests.sh src/*.sh src/GEISA-LEE-tests/tests.d/*.sh \
 && pylint src/launch_glee_conformance_tests_serial.py && black --check --diff src/launch_glee_conformance_tests_serial.py \
+&& pylint src/launch_gadm_conformance_tests.py && black --check --diff src/launch_gadm_conformance_tests.py \
 && clang-format --Werror --dry-run src/GEISA-API-tests/src/*.c src/GEISA-API-tests/src/*.h \
 && cd src/GEISA-API-tests/src/ && mkdir -p build && protoc --c_out=build schemas/*.proto && cd - \
 && clang-tidy src/GEISA-API-tests/src/*.c src/GEISA-API-tests/src/*.h -- -I src/GEISA-API-tests/src/build \
@@ -18,10 +19,10 @@ docker_run_args='--network=host -e CONFORMANCE_SCP_ARGS -e CONFORMANCE_SSH_ARGS 
 command='shellcheck -xo all launch_conformance_tests.sh src/*.sh src/GEISA-LEE-tests/tests.d/*.sh'
 
 [pylint]
-command='pylint src/launch_glee_conformance_tests_serial.py'
+command='pylint src/launch_glee_conformance_tests_serial.py src/launch_gadm_conformance_tests.py'
 
 [black]
-command='black --check --diff src/launch_glee_conformance_tests_serial.py'
+command='black --check --diff src/launch_glee_conformance_tests_serial.py src/launch_gadm_conformance_tests.py'
 
 [clang-format]
 command='clang-format --Werror --dry-run src/GEISA-API-tests/src/*.c src/GEISA-API-tests/src/*.h'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ GEISA-LEE-tests.tar.gz
 src/GEISA-API-tests/build_rootfs
 gapi-conformance-tests.squashfs
 launch_gapi_test_app.sh
+data/
+venv/
+Californium3.server.properties

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 # GEISA Conformance - a GEISA validation framework
 
 GEISA conformance is designed to help developers to validate the conformance
-with the [GEISA Specification](https://github.com/geisa/specification).  
+with the [GEISA Specification](https://github.com/geisa/specification).
 
-The GEISA Specification is an effort by the Grid Edge Interoperability and Security Alliance to define a consistent, secure, and interoperable computing environment for embedded devices at the very edge of the electric utility grid, like electric meters and distribution automation devices, for the benefit of utilities, platform vendors, and software vendors.  If you would like to get involved, please head over to our Wiki page for details on participation (https://lfenergy.org/projects/geisa/).  Follow the onboarding link for details about participating in our community process.  
+The GEISA Specification is an effort by the Grid Edge Interoperability and Security Alliance to define a consistent, secure, and interoperable computing environment for embedded devices at the very edge of the electric utility grid, like electric meters and distribution automation devices, for the benefit of utilities, platform vendors, and software vendors.  If you would like to get involved, please head over to our Wiki page for details on participation (https://lfenergy.org/projects/geisa/).  Follow the onboarding link for details about participating in our community process.
 
 ## Usage
 
@@ -41,6 +41,11 @@ The automatic test launcher requires the following requirements:
     - qemu-user-static (On ubuntu, install with `sudo apt install qemu-user-static`)
     - mksquashfs (On ubuntu, install with `sudo apt install squashfs-tools`)
     - launch_gapi_test_app.sh script see [API Launching script](#api-launching-script) section
+  * For adm tests:
+    - bsdmainutils (On ubuntu, install with `sudo apt install bsdmainutils`)
+    - curl (On ubuntu, install with `sudo apt install curl`)
+    - default-jre-headless (On ubuntu, install with `sudo apt install default-jre-headless`)
+    - wget (On ubuntu, install with `sudo apt install wget`)
 
 A docker support is also available to launch the tests with a container, it requires:
   - cqfd (See [requirements](https://github.com/savoirfairelinux/cqfd?tab=readme-ov-file#requirements) and [installation](https://github.com/savoirfairelinux/cqfd?tab=readme-ov-file#installingremoving-cqfd) steps on github)
@@ -74,6 +79,17 @@ Optional options:
 * `--no-gapi-tests`: Do not run GEISA Application Programming Interface Conformance tests
 * `--help`: display help message
 
+GADM test options (optional):
+* `--host-ip <host_ip>`: IP address of the host running the EMS server
+* `--api-endpoint <endpoint>`: EMS API endpoint (default: <server-url>/api)
+* `--client-name <name>`: ADM client endpoint name (default: geisa_adm_client)
+* `--client-path <path>`: Path to ADM client binary on the board (default: /usr/bin/adm_client)
+* `--client-psk-identity <id>`: PSK identity for the ADM client (default: <client-name>)
+* `--client-psk-value <value>`: PSK secret for the ADM client (default: auto-generated hex string of length 16)
+* `--client-params <params>`: Parameters to start the ADM client (use case: <client-path> <client-params>)
+* `--package-path <path>`: Path to the ADM package to test (a squashfs file containing the client binary for the current implementation)
+* `--server-url <url>`: EMS server URL (default: http://localhost:8080)
+
 Environment variables can also be used to configure the script:
 * `CONFORMACE_SCP_ARGS`: Additional arguments for the `scp` command
 * `CONFORMACE_SSH_ARGS`: Additional arguments for the `ssh` command
@@ -82,6 +98,12 @@ The tests names correspond to a part of the filename.
 Example: `GLEE_TESTS="os_requirements_tests application_isolation"` will run only the `os_requirements_tests` and `application_isolation` tests.
 
 A xml and pdf report will be generated in the `reports` directory.
+
+For ADM tests, if your software package is outside the project directory, you may want to mount its directory in the container by setting the `CQFD_EXTRA_RUN_ARGS` environment variable before running tests. For example:
+
+```bash
+export CQFD_EXTRA_RUN_ARGS="-v path/to/package:path/to/package"
+```
 
 To use the docker support run with the following commands:
 ```bash

--- a/launch_conformance_tests.sh
+++ b/launch_conformance_tests.sh
@@ -31,21 +31,35 @@ GEISA Conformance Launch script
 Usage: $0 [options]
 
 Required options:
-  --ip <board_ip>     Specify the IP address of the board to run tests on
+  --ip <board_ip>     				Specify the IP address of the board to run tests on
 or
-  --serial <serial_port>  Specify the serial port of the board to run tests on
+  --serial <serial_port>  			Specify the serial port of the board to run tests on
 
 Optional options:
-  --user <username>   Specify the username for the target device (default: root)
-  --password <password>  Specify the password for the target device (default: empty)
-  --no-reports        Do not generate test reports (only run tests and display results)
-  --baudrate <baudrate> Specify the baudrate for the serial port of the board (default: 115200)
-  --no-glee-tests        Do not run GEISA Linux Execution Environment Conformance tests
-  --no-gadm-tests        Do not run GEISA Application & Device Management Conformance tests
-  --no-gapi-tests        Do not run GEISA Application Programming Interface Conformance tests
-  --help              Show this help message
+  --user <username>   				Specify the username for the target device (default: root)
+  --password <password>  			Specify the password for the target device (default: empty)
+  --no-reports        				Do not generate test reports (only run tests and display results)
+  --baudrate <baudrate> 			Specify the baudrate for the serial port of the board (default: 115200)
+  --no-glee-tests        			Do not run GEISA Linux Execution Environment Conformance tests
+  --no-gadm-tests        			Do not run GEISA Application & Device Management Conformance tests
+  --no-gapi-tests        			Do not run GEISA Application Programming Interface Conformance tests
+  --help              				Show this help message
+
+GADM test options (optional):
+  --host-ip <host_ip>				IP address of the host running the EMS server.
+									If not specified, the host IP is automatically deduced from the active SSH
+									session (i.e. the IP the board sees as the SSH client). In that case the
+									EMS server must run on the same host as the one initiating the SSH connection.
+  --api-endpoint <endpoint>			EMS API endpoint (default: <server-url>/api)
+  --client-name <name>				ADM client endpoint name (default: geisa_adm_client)
+  --client-path <path>				Path to ADM client binary on the board (default: /usr/bin/adm_client)
+  --client-psk-identity <id>		PSK identity for the ADM client (default: <client-name>)
+  --client-psk-value <value>		PSK secret for the ADM client (default: auto-generated hex string of length 16)
+  --client-params <p>				Parameters to start the ADM client (use case: <client-path> <client-params>)
+  --package-path <path>				Path to the ADM package to test (a squashfs file containing the client binary for the current implementation)
+  --server-url <url>				EMS server URL (default: http://localhost:8080)
 EOF
-	exit 1
+    exit 1
 }
 
 while [[ "$#" -gt 0 ]]; do
@@ -92,6 +106,42 @@ while [[ "$#" -gt 0 ]]; do
 			echo -e "${RED}Error:${ENDCOLOR} Baudrate cannot be empty"
 			usage
 		fi
+		shift 2
+		;;
+		--host-ip)
+		HOST_IP="$2"
+		shift 2
+		;;
+		--package-path)
+		PACKAGE_PATH="$2"
+		shift 2
+		;;
+		--server-url)
+		ADM_SERVER_URL="$2"
+		shift 2
+		;;
+		--api-endpoint)
+		ADM_API_ENDPOINT="$2"
+		shift 2
+		;;
+		--client-name)
+		ADM_CLIENT_NAME="$2"
+		shift 2
+		;;
+		--client-path)
+		ADM_CLIENT_PATH="$2"
+		shift 2
+		;;
+		--client-psk-identity)
+		ADM_CLIENT_PSK_IDENTITY="$2"
+		shift 2
+		;;
+		--client-psk-value)
+		ADM_CLIENT_PSK_VALUE="$2"
+		shift 2
+		;;
+		--client-params)
+		ADM_CLIENT_PARAMS="$2"
 		shift 2
 		;;
 		--no-glee-tests)
@@ -184,9 +234,19 @@ fi
 
 if [[ -z ${NO_GADM_TESTS} ]]; then
 	if ! ${NO_REPORTS}; then
-		launch_gadm_tests_with_report "${TOPDIR}"
-	else
-		launch_gadm_tests_without_report "${TOPDIR}"
+		launch_gadm_tests_with_report \
+			"${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}" \
+			"${TOPDIR}" "${HOST_IP}" "${PACKAGE_PATH}" \
+			"${ADM_SERVER_URL}" "${ADM_API_ENDPOINT}" "${ADM_CLIENT_NAME}" \
+			"${ADM_CLIENT_PATH}" "${ADM_CLIENT_PSK_IDENTITY}" \
+			"${ADM_CLIENT_PSK_VALUE}" "${ADM_CLIENT_PARAMS}"
+		else
+		launch_gadm_tests_without_report \
+			"${BOARD_IP}" "${BOARD_USER}" "${BOARD_PASSWORD}" \
+			"${TOPDIR}" "${HOST_IP}" "${PACKAGE_PATH}" \
+			"${ADM_SERVER_URL}" "${ADM_API_ENDPOINT}" "${ADM_CLIENT_NAME}" \
+			"${ADM_CLIENT_PATH}" "${ADM_CLIENT_PSK_IDENTITY}" \
+			"${ADM_CLIENT_PSK_VALUE}" "${ADM_CLIENT_PARAMS}"
 	fi
 fi
 

--- a/src/GEISA-ADM-tests/cukinia.conf
+++ b/src/GEISA-ADM-tests/cukinia.conf
@@ -6,6 +6,14 @@ GEISA_ADM_TESTS_DIR=$(dirname "$CUKINIA_DIR")/GEISA-ADM-tests
 cukinia_log "$(_colorize white2 "--- GEISA ADM conformance tests ---")"
 
 . $GEISA_ADM_TESTS_DIR/tests_configuration.conf
+
+_py() {
+    python3 "${topdir}/src/launch_gadm_conformance_tests.py" \
+        --api-endpoint "${api_endpoint}" \
+        --client-name "${client_name}" \
+        "$@"
+}
+
 cukinia_conf_include $GEISA_ADM_TESTS_DIR/tests.d/*.conf
 
 cukinia_log "GEISA ADM conformance tests: ran $cukinia_tests tests, $(_colorize red "$cukinia_failures failed"), $(_colorize yellow2 "$cukinia_skip skipped")"

--- a/src/GEISA-ADM-tests/tests.d/01-pre-update.conf
+++ b/src/GEISA-ADM-tests/tests.d/01-pre-update.conf
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Southern California Edison
+
+logging suite "GEISA ADM - Conditions before package update"
+cukinia_log "$(_colorize blue "--- GEISA ADM - Conditions before package update ---")"
+
+as "Checking if UPDATE_STATE is INITIAL(0) before package update" \
+    cukinia_cmd _py \
+    --command "read" \
+    --object-uri "9/0/7" \
+    --expected-key "content.value" \
+    --expected-value "0"
+
+as "Checking if ACTIVATION_STATE is DISABLED(0) before package activation" \
+    cukinia_cmd _py \
+    --command "read" \
+    --object-uri "9/0/12" \
+    --expected-key "content.value" \
+    --expected-value "False"

--- a/src/GEISA-ADM-tests/tests.d/02-post-update.conf
+++ b/src/GEISA-ADM-tests/tests.d/02-post-update.conf
@@ -1,0 +1,26 @@
+# Copyright (C) 2026 Southern California Edison
+
+logging suite "GEISA ADM - Conditions after package update"
+cukinia_log "$(_colorize blue "--- GEISA ADM - Conditions after package update ---")"
+
+as "Checking if package can be pushed to client" \
+    cukinia_cmd verbose _py \
+    --command "push" \
+    --object-uri "9/0/2" \
+    --expected-key "success" \
+    --expected-value "True" \
+    --package-path "${package_path}"
+
+as "Checking if UPDATE_STATE is changed to DELIVERED(3) after package update" \
+    cukinia_cmd verbose _py \
+    --command "read" \
+    --object-uri "9/0/7" \
+    --expected-key "content.value" \
+    --expected-value "3"
+
+as "Checking if ACTIVATION_STATE is DISABLED(0) before package activation" \
+    cukinia_cmd verbose _py \
+    --command "read" \
+    --object-uri "9/0/12" \
+    --expected-key "content.value" \
+    --expected-value "False"

--- a/src/GEISA-ADM-tests/tests.d/03-installation.conf
+++ b/src/GEISA-ADM-tests/tests.d/03-installation.conf
@@ -1,0 +1,25 @@
+# Copyright (C) 2026 Southern California Edison
+
+logging suite "GEISA ADM - Conditions after package installation"
+cukinia_log "$(_colorize blue "--- GEISA ADM - Conditions after package installation ---")"
+
+as "Checking if package can be installed on client" \
+    cukinia_cmd _py \
+    --command "execute" \
+    --object-uri "9/0/4" \
+    --expected-key "success" \
+    --expected-value "True"
+
+as "Checking if UPDATE_STATE is changed to INSTALLED(4) after package installation" \
+    cukinia_cmd _py \
+    --command "read" \
+    --object-uri "9/0/7" \
+    --expected-key "content.value" \
+    --expected-value "4"
+
+as "Checking if ACTIVATION_STATE is DISABLED(0) before package activation" \
+    cukinia_cmd _py \
+    --command "read" \
+    --object-uri "9/0/12" \
+    --expected-key "content.value" \
+    --expected-value "False"

--- a/src/GEISA-ADM-tests/tests.d/04-activation.conf
+++ b/src/GEISA-ADM-tests/tests.d/04-activation.conf
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Southern California Edison
+
+logging suite "GEISA ADM - Conditions after package activation"
+cukinia_log "$(_colorize blue "--- GEISA ADM - Conditions after package activation ---")"
+
+as "Checking if package can be activated on client" \
+    cukinia_cmd _py \
+    --command "execute" \
+    --object-uri "9/0/10" \
+    --expected-key "success" \
+    --expected-value "True"
+
+as "Checking if ACTIVATION_STATE is ACTIVATED(1) after package activation" \
+    cukinia_cmd _py \
+    --command "read" \
+    --object-uri "9/0/12" \
+    --expected-key "content.value" \
+    --expected-value "True"

--- a/src/GEISA-ADM-tests/tests.d/05-deactivation.conf
+++ b/src/GEISA-ADM-tests/tests.d/05-deactivation.conf
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Southern California Edison
+
+logging suite "GEISA ADM - Conditions after package deactivation"
+cukinia_log "$(_colorize blue "--- GEISA ADM - Conditions after package deactivation ---")"
+
+as "Checking if package can be deactivated on client" \
+    cukinia_cmd _py \
+    --command "execute" \
+    --object-uri "9/0/11" \
+    --expected-key "success" \
+    --expected-value "True"
+
+as "Checking if ACTIVATION_STATE is DEACTIVATED(0) after package deactivation" \
+    cukinia_cmd _py \
+    --command "read" \
+    --object-uri "9/0/12" \
+    --expected-key "content.value" \
+    --expected-value "False"

--- a/src/GEISA-ADM-tests/tests.d/06-uninstallation.conf
+++ b/src/GEISA-ADM-tests/tests.d/06-uninstallation.conf
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Southern California Edison
+
+logging suite "GEISA ADM - Conditions after package uninstallation"
+cukinia_log "$(_colorize blue "--- GEISA ADM - Conditions after package uninstallation ---")"
+
+as "Checking if package can be uninstalled on client" \
+    cukinia_cmd _py \
+    --command "execute" \
+    --object-uri "9/0/6" \
+    --expected-key "success" \
+    --expected-value "true"
+
+as "Checking if UPDATE_STATE is reset to INITIAL(0) after package uninstallation" \
+    cukinia_cmd _py \
+    --command "read" \
+    --object-uri "9/0/7" \
+    --expected-key "content.value" \
+    --expected-value "0"

--- a/src/launch_gadm_conformance_tests.py
+++ b/src/launch_gadm_conformance_tests.py
@@ -1,0 +1,219 @@
+"""
+GEISA Application & Device Management Conformance Launch script.
+Copyright (C) 2026 Southern California Edison
+
+GEISA Conformance is free software, distributed under the Apache License
+version 2.0. See LICENSE for details.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+from pathlib import Path
+
+COMMANDS = ["push", "read", "write", "execute"]
+
+
+def _parse_response_body(body):
+    """Decode JSON responses and preserve raw bodies otherwise."""
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return body
+
+
+class GadmConformanceTest:
+    """GEISA ADM conformance test runner."""
+
+    def __init__(self):
+        self.api_endpoint = None
+        self.client_name = None
+        self.object_uri = None
+        self.expected_key = None
+        self.expected_value = None
+        self.package_path = None
+        self.payload = None
+
+    @staticmethod
+    def _build_url(api_endpoint, client_name, object_uri, fmt, timeout=5):
+        return (
+            f"{api_endpoint}/clients/{client_name}/{object_uri}"
+            f"?timeout={timeout}&format={fmt}"
+        )
+
+    @staticmethod
+    def _get_value(response, key_path):
+        """Resolve a dot-separated key path in a nested dict/JSON object."""
+        value = response
+        for key in key_path.split("."):
+            if not isinstance(value, dict) or key not in value:
+                return None
+            value = value[key]
+        return value
+
+    @staticmethod
+    def _api_request(method, url, timeout, payload=None):
+        """Send an HTTP request and decode the JSON response when possible."""
+        data = None
+        headers = {}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = response.read().decode("utf-8")
+                return response.status, _parse_response_body(body)
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8")
+            return error.code, _parse_response_body(body)
+
+    def _check_response(self, status, response):
+        """Validate the API response against expected key/value."""
+        if status != 200:
+            return False
+        value = GadmConformanceTest._get_value(response, self.expected_key)
+        if value is None:
+            return False
+        return str(value).lower() == str(self.expected_value).lower()
+
+    def test_read(self):
+        """Read a resource through the Leshan HTTP API."""
+        url = GadmConformanceTest._build_url(
+            self.api_endpoint, self.client_name, self.object_uri, "TEXT"
+        )
+        status, response = GadmConformanceTest._api_request("GET", url, timeout=5)
+        return self._check_response(status, response)
+
+    def test_write(self):
+        """Write a resource through the Leshan HTTP API."""
+        url = GadmConformanceTest._build_url(
+            self.api_endpoint, self.client_name, self.object_uri, "TEXT"
+        )
+        status, response = GadmConformanceTest._api_request(
+            "PUT", url, timeout=5, payload=self.payload
+        )
+        return self._check_response(status, response)
+
+    def test_execute(self):
+        """Execute a resource through the Leshan HTTP API."""
+        url = GadmConformanceTest._build_url(
+            self.api_endpoint, self.client_name, self.object_uri, "TEXT"
+        )
+        status, response = GadmConformanceTest._api_request(
+            "POST", url, timeout=5, payload=self.payload
+        )
+        return self._check_response(status, response)
+
+    def test_push(self):
+        """Push the application package to the client."""
+        if not Path(self.package_path).is_file():
+            return False
+
+        package_data = Path(self.package_path).read_bytes().hex()
+        payload = {
+            "id": 2,
+            "kind": "singleResource",
+            "value": package_data,
+            "type": "opaque",
+        }
+        url = GadmConformanceTest._build_url(
+            self.api_endpoint, self.client_name, self.object_uri, "OPAQUE", 10
+        )
+        status, response = GadmConformanceTest._api_request(
+            "PUT", url, timeout=10, payload=payload
+        )
+        return self._check_response(status, response)
+
+    def parse_arguments(self):
+        """Parse command line arguments and populate instance variables."""
+        parser = argparse.ArgumentParser(
+            description="GEISA ADM conformance launch script via Leshan HTTP API."
+        )
+        parser.add_argument(
+            "--api-endpoint",
+            required=True,
+            help="Leshan HTTP API base endpoint",
+        )
+        parser.add_argument(
+            "--client-name",
+            required=True,
+            help="ADM client name",
+        )
+        parser.add_argument(
+            "--command",
+            required=True,
+            choices=COMMANDS,
+        )
+        parser.add_argument(
+            "--object-uri",
+            required=True,
+            help="URI of the object to operate on",
+        )
+        parser.add_argument(
+            "--expected-key",
+            required=True,
+            help="JSON key to check in the response body",
+        )
+        parser.add_argument(
+            "--expected-value",
+            required=True,
+            help="Expected value for --expected-key",
+        )
+        parser.add_argument(
+            "--package-path",
+            default=None,
+            help=(
+                "Path to the application package squashfs on the host."
+                " To be used with the 'push' command."
+            ),
+        )
+        parser.add_argument(
+            "--payload",
+            default=None,
+            help="JSON payload to write to the ADM client. Default is None.",
+        )
+        args = parser.parse_args()
+        self.api_endpoint = args.api_endpoint
+        self.client_name = args.client_name
+        self.object_uri = args.object_uri
+        self.expected_key = args.expected_key
+        self.expected_value = args.expected_value
+        self.package_path = args.package_path
+        self.payload = json.loads(args.payload) if args.payload else None
+        return args.command
+
+    def run(self, command):
+        """Dispatch and run the configured command."""
+        dispatch = {
+            "push": self.test_push,
+            "read": self.test_read,
+            "write": self.test_write,
+            "execute": self.test_execute,
+        }
+        return dispatch[command]()
+
+
+def main():
+    """Main function."""
+    test = GadmConformanceTest()
+    command = test.parse_arguments()
+
+    try:
+        result = test.run(command)
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as error:
+        print(f"Error: {error}", file=sys.stderr, flush=True)
+        sys.exit(1)
+
+    sys.exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/launch_gadm_conformance_tests.sh
+++ b/src/launch_gadm_conformance_tests.sh
@@ -1,29 +1,309 @@
 #!/bin/bash
 #
 # GEISA Application & Device Management Conformance functions
-# Copyright (C) 2025 Southern California Edison
+# Copyright (C) 2026 Southern California Edison
 #
 # GEISA Conformance is free software, distributed under the Apache License
 # version 2.0. See LICENSE for details.
 
-launch_gadm_tests_with_report() {
+RED="\e[31m"
+ENDCOLOR="\e[0m"
+declare CONFORMANCE_SSH_ARGS
+declare CONFORMANCE_SCP_ARGS
+
+SSH() {
+	#shellcheck disable=SC2086
+	sshpass -p "${board_password}" ssh ${CONFORMANCE_SSH_ARGS} -o LogLevel=QUIET -o StrictHostKeyChecking=no "${board_user}@${board_ip}" "$@"
+}
+
+SCP() {
+	#shellcheck disable=SC2086
+	sshpass -p "${board_password}" scp ${CONFORMANCE_SCP_ARGS} -o StrictHostKeyChecking=no "$@"
+}
+
+generate_gadm_psk() {
+	hexdump -vn 16 -e '/1 "%02x"' /dev/urandom
+}
+
+create_gadm_test_squashfs() {
+	local package_dir="$1"
+	local rootfs_dir="${package_dir}/rootfs"
+	local bin_dir="${rootfs_dir}/usr/bin"
+	local package_name="geisa-app-1-1.0.1.squashfs"
+	local package_path="${package_dir}/${package_name}"
+
+	mkdir -p "${bin_dir}"
+
+	cat > "${bin_dir}/geisa-app-1" <<'EOF'
+#!/bin/sh
+echo "Hello, GEISA!"
+EOF
+
+	chmod +x "${bin_dir}/geisa-app-1"
+	mksquashfs "${rootfs_dir}" "${package_path}" -noappend -quiet > /dev/null 2>&1 || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to create squashfs for ADM client package"
+		exit 1
+	}
+	rm -rf "${rootfs_dir}"
+
+	echo "${package_path}"
+}
+
+cleanup_gadm_test_squashfs() {
+	local package_dir="$1"
+	local package_path="${package_dir}/geisa-app-1-1.0.1.squashfs"
+
+	if [[ -f "${package_path}" ]]; then
+		rm -f "${package_path}"
+	fi
+}
+
+deduce_host_ip_from_ssh() {
+	local ssh_client
+	ssh_client=$(SSH "echo \$SSH_CLIENT")
+	echo "${ssh_client}" | awk '{print $1}'
+}
+
+wait_for_gadm_server() {
+	local server_url="$1"
+	local attempts=30
+	local attempt=0
+
+	while (( attempt < attempts )); do
+		if curl --silent --output /dev/null --fail --max-time 5 "${server_url}"; then
+			return
+		fi
+		sleep 1
+		attempt=$((attempt + 1))
+	done
+
+	echo -e "${RED}Error:${ENDCOLOR} Leshan server did not become ready"
+	exit 1
+}
+
+start_gadm_server() {
+	local ems_server_path="$1"
+
+	echo ""
+	echo "Starting Leshan EMS server"
+	java -jar "${ems_server_path}" >/dev/null 2>&1 &
+	server_pid=$!
+
+	export server_pid
+}
+
+start_gadm_client_on_board() {
+	local host_ip="$1"
+	local client_path="$2"
+	local client_psk_identity="$3"
+	local client_psk_value="$4"
+	local client_start_params="$5"
+
+	echo ""
+	echo "Starting ADM client on board"
+	SSH "pkill -f '${client_path}' >/dev/null 2>&1 || true"
+	SSH "nohup ${client_path} ${client_start_params} >/dev/null 2>/tmp/adm_client.log &"
+	sleep 5 	# Allow some time for DTLS handshake
+	client_pid=$(SSH "pgrep -f '${client_path}'")
+
+	if [[ -z "${client_pid}" ]]; then
+		echo -e "${RED}Error:${ENDCOLOR} Failed to start ADM client on board"
+		exit 1
+	fi
+
+	export client_pid
+}
+
+cleanup_gadm_ssh() {
+	local board_ip="$1"
+	local board_user="$2"
+	local board_password="$3"
+	local client_pid="$4"
+	local server_pid="$5"
+
+	echo ""
+	echo "Cleaning up ADM test client and server processes"
+	echo ""
+	if [[ -n "${client_pid}" ]]; then
+		SSH "kill ${client_pid} >/dev/null 2>&1 || true"
+	fi
+
+	if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" >/dev/null 2>&1; then
+		kill "${server_pid}" >/dev/null 2>&1 || true
+		wait "${server_pid}" 2>/dev/null || true
+	fi
+}
+
+provision_gadm_client_credentials() {
+	local api_endpoint="$1"
+	local endpoint="$2"
+	local identity="$3"
+	local key="$4"
+
+	curl -s -X PUT \
+		-H "Content-Type: application/json" \
+		-d "{\"endpoint\":\"${endpoint}\",\"tls\":{\"mode\":\"psk\",\"details\":{\"identity\":\"${identity}\",\"key\":\"${key}\"}}}" \
+		"${api_endpoint}/security/clients/"
+}
+
+prepare_gadm_test_files() {
 	local topdir="$1"
 
 	echo ""
-	echo "Starting GEISA Application & Device Management Conformance Tests"
-	"${topdir}"/src/cukinia/cukinia -f junitxml -o "${topdir}"/reports/geisa-adm-conformance-report.xml "${topdir}"/src/GEISA-ADM-tests/cukinia.conf
+	echo "Preparing GEISA ADM conformance test files"
+	mkdir -p "${topdir}/reports" || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to create test directory"
+		exit 1
+	}
+	chmod +x "${topdir}/src/cukinia/cukinia" || {
+		echo -e "${RED}Error:${ENDCOLOR} Failed to set execute permission on cukinia"
+		exit 1
+	}
+}
+
+launch_gadm_tests() {
+	local board_ip="$1"
+	local board_user="$2"
+	local board_password="$3"
+	local topdir="$4"
+	local host_ip="${5:-}"
+	local package_path="$6"
+	local server_url="${7:-http://localhost:8080}"
+	local api_endpoint="${8:-${server_url}/api}"
+	local client_name="${9:-geisa_adm_client}"
+	local client_path="${10:-/usr/bin/adm_client}"		# Default path to ADM client running on LEE-mockup platform
+	local client_psk_identity="${11:-${client_name}}"
+	local client_psk_value="${12:-$(generate_gadm_psk)}"
+	local client_start_params="${13:-}"
+	local with_report="${14:-false}"
+
+	local ems_server_path="${topdir}/src/leshan/leshan_ems_server.jar"
+	local server_pid=""
+	local client_pid=""
+	local adm_test_exit_code=0
+
+	if ! ping -c 1 -W 2 "${board_ip}" >/dev/null 2>&1; then
+		echo -e "${RED}Error:${ENDCOLOR} Unable to reach board at ${board_ip}"
+		exit 1
+	fi
+
+	# If host_ip is not provided, deduce it from the SSH session.
+	# This requires the EMS server to be running on the same host as the one
+	# initiating the SSH connection to the board.
+	# Note that this is specific to a Wakaama-based ADM client. Other implementation may not
+	# require the host IP to be specified at all, or may require a different method of deducing it.
+	if [[ -z "${host_ip}" ]]; then
+		echo ""
+		echo "No host IP provided, deducing from SSH session..."
+		host_ip=$(deduce_host_ip_from_ssh)
+		if [[ -z "${host_ip}" ]]; then
+			echo -e "${RED}Error:${ENDCOLOR} Could not deduce host IP from SSH session. Please specify --host-ip explicitly."
+			exit 1
+		fi
+		echo "Deduced host IP: ${host_ip}"
+	fi
+
+	client_start_params="${client_start_params:-"-4 -h ${host_ip} -p 5684 -i ${client_psk_identity} -s ${client_psk_value}"}"
+
+	if [[ -z "${package_path}" ]]; then
+		echo ""
+		echo "No package specified, creating GEISA ADM test package squashfs..."
+		package_path=$(create_gadm_test_squashfs "${topdir}")
+	fi
+
+	if [[ ! -f "${ems_server_path}" ]]; then
+		echo -e "${RED}Error:${ENDCOLOR} Leshan jar not found at ${ems_server_path}"
+		exit 1
+	fi
+
+	echo ""
+	echo "Starting GEISA Application & Device Management Conformance Tests on board at ${board_ip}"
+	echo "Connecting to board as user '${board_user}'"
+
+	# Exporting variables for cukinia
+	export topdir api_endpoint client_name package_path
+	prepare_gadm_test_files "${topdir}"
+
+	# Leshan server and ADM client setup
+	start_gadm_server "${ems_server_path}"
+	wait_for_gadm_server "${server_url}"
+	provision_gadm_client_credentials "${api_endpoint}" "${client_name}" "${client_psk_identity}" "${client_psk_value}"
+	sleep 3
+	start_gadm_client_on_board "${host_ip}" "${client_path}" "${client_psk_identity}" "${client_psk_value}" "${client_start_params}"
+
+	echo ""
+	echo "Launching tests..."
+	if [[ "${with_report}" == "true" ]]; then
+		"${topdir}"/src/cukinia/cukinia -f junitxml -o "${topdir}/reports/geisa-adm-conformance-report.xml" "${topdir}/src/GEISA-ADM-tests/cukinia.conf"
+	else
+		"${topdir}"/src/cukinia/cukinia "${topdir}/src/GEISA-ADM-tests/cukinia.conf"
+	fi
 	adm_test_exit_code=$?
 
+	cleanup_gadm_ssh "${board_ip}" "${board_user}" "${board_password}" "${client_pid}" "${server_pid}"
+	cleanup_gadm_test_squashfs "${topdir}"
+
 	export adm_test_exit_code
+}
+
+launch_gadm_tests_with_report() {
+	local board_ip="$1"
+	local board_user="$2"
+	local board_password="$3"
+	local topdir="$4"
+	local host_ip="$5"
+	local package_path="$6"
+	local server_url="$7"
+	local api_endpoint="$8"
+	local client_name="${9}"
+	local client_path="${10}"
+	local client_psk_identity="${11}"
+	local client_psk_value="${12}"
+	local client_start_params="${13}"
+
+	launch_gadm_tests "${board_ip}" \
+		"${board_user}" \
+		"${board_password}" \
+		"${topdir}" \
+		"${host_ip}" \
+		"${package_path}" \
+		"${server_url}" \
+		"${api_endpoint}" \
+		"${client_name}" \
+		"${client_path}" \
+		"${client_psk_identity}" \
+		"${client_psk_value}" \
+		"${client_start_params}" \
+		"true"
 }
 
 launch_gadm_tests_without_report() {
-	local topdir="$1"
+	local board_ip="$1"
+	local board_user="$2"
+	local board_password="$3"
+	local topdir="$4"
+	local host_ip="$5"
+	local package_path="$6"
+	local server_url="$7"
+	local api_endpoint="$8"
+	local client_name="${9}"
+	local client_path="${10}"
+	local client_psk_identity="${11}"
+	local client_psk_value="${12}"
+	local client_start_params="${13}"
 
-	echo ""
-	echo "Starting GEISA Application & Device Management Conformance Tests"
-	"${topdir}"/src/cukinia/cukinia "${topdir}"/src/GEISA-ADM-tests/cukinia.conf
-	adm_test_exit_code=$?
-
-	export adm_test_exit_code
-}
+	launch_gadm_tests "${board_ip}" \
+		"${board_user}" \
+		"${board_password}" \
+		"${topdir}" \
+		"${host_ip}" \
+		"${package_path}" \
+		"${server_url}" \
+		"${api_endpoint}" \
+		"${client_name}" \
+		"${client_path}" \
+		"${client_psk_identity}" \
+		"${client_psk_value}" \
+		"${client_start_params}" \
+		"false"
+	}


### PR DESCRIPTION
## Description

This PR provides an initial base for the GEISA EMS-ADM conformance test implementation.

The first batch of tests focuses on establishing communication between the EMS server and an ADM client running on a GEISA-conformant edge device, using DTLS with pre-shared keys.

Most of the implemented test coverage targets `object_software`, especially package lifecycle management scenarios.

## Changes
* Add a Leshan-based EMS test server.
* Add helper scripts for REST queries against the EMS server.
* Add Cukinia configuration and Python wrapper support for HTTP requests.
* Add ADM conformance test scripts for:
  * pre-update condition
  * post-update condition
  * post-installation condition
  * post-activation condition
  * post-deactivation condition
  * post-uninstallation condition
* Add launcher scripts for running the ADM conformance tests.
* Add Dockerfile dependencies required by the ADM test environment.
* Add linting support for ADM test scripts.
* Update `.gitignore` for test-related artifacts and virtual environment setup.
* Add README instructions for running the GEISA ADM tests.

## Scope

This is intended as a starting point for the GEISA ADM conformance test suite. Further test cases and refinements can be added on top of this base as the ADM test coverage evolves.
