### PR TITLE
Add initial GEISA conformance map tool structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ gapi-conformance-tests.squashfs
 launch_gapi_test_app.sh
 data/
 venv/
+
+/build/conformance-map/

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,0 +1,41 @@
+<!--
+Copyright 2025-2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
+
+Licensed under the Apache License, Version 2.0. See LICENSE.
+-->
+
+# Conformance Map Data
+
+This directory contains the reviewed data used by GEISA Conformance Map.
+
+The map connects:
+
+- requirements found in the GEISA specification
+- contract rules defined by protobufs, JSON Schemas, and profiles
+- Cukinia tests that provide evidence for those requirements and rules
+
+Generated candidates, reports, and temporary source snapshots are written under
+`build/conformance-map/` and are not committed.
+
+## Layout
+
+- `review/` contains decisions made while reviewing extracted requirements
+- `mappings/` connects approved requirements and contract rules to tests
+- `baselines/` stores reviewed snapshots for released GEISA versions
+- `schemas/` validates the files maintained in this directory
+
+LEE and API are the initial focus. ADM and VEE may be inventoried, but their
+test coverage work is currently parked.
+
+## Workflow
+
+1. Select a released GEISA version, exact commit, or current development source
+2. Extract requirements and contract rules
+3. Review new or changed results
+4. Map approved items to existing tests
+5. Identify missing or partial coverage
+6. Generate reports or optional test scaffolding
+
+The reviewed files in this directory are the project record. Generated output
+can be recreated as needed from the selected sources.

--- a/requirements/baselines/README.md
+++ b/requirements/baselines/README.md
@@ -1,0 +1,22 @@
+<!--
+Copyright 2025-2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
+
+Licensed under the Apache License, Version 2.0. See LICENSE.
+-->
+
+# Released Baselines
+
+This directory stores reviewed Conformance Map snapshots for released GEISA
+versions.
+
+Each baseline records:
+
+- the exact specification revision
+- the exact schema source and revision
+- the conformance revision
+- approved requirement and contract-rule records
+- approved test mappings
+
+Current development sources such as `main` or `latest` are analyzed under
+`build/conformance-map/` and are not stored here.

--- a/requirements/mappings/README.md
+++ b/requirements/mappings/README.md
@@ -1,0 +1,21 @@
+<!--
+Copyright 2025-2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
+
+Licensed under the Apache License, Version 2.0. See LICENSE.
+-->
+
+# Test Mappings
+
+This directory stores approved links between GEISA requirements or contract
+rules and Cukinia tests.
+
+A mapping records:
+
+- what a test covers
+- where the test lives
+- what evidence the test provides
+- whether coverage is full, partial, or diagnostic only
+
+The tool may suggest likely matches, but a suggestion does not count as
+coverage until it has been reviewed and accepted.

--- a/requirements/review/README.md
+++ b/requirements/review/README.md
@@ -1,0 +1,23 @@
+<!--
+Copyright 2025-2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
+
+Licensed under the Apache License, Version 2.0. See LICENSE.
+-->
+
+# Review Decisions
+
+This directory stores conformance team review decisions applied to the
+generated requirements and contract rules.
+
+Reviewers may:
+
+- approve or reject an extracted item
+- split or merge requirements
+- assign a stable requirement or contract-rule ID
+- clarify the condition
+- change applicability or testability
+- record why an item is parked or excluded
+
+The complete catalog is generated from the specification source plus these
+decisions.  Specification text should not be copied and maintained here.

--- a/requirements/schemas/README.md
+++ b/requirements/schemas/README.md
@@ -1,0 +1,21 @@
+<!--
+Copyright 2025-2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
+
+Licensed under the Apache License, Version 2.0. See LICENSE.
+-->
+
+# Conformance Map Schemas
+
+This directory will contain JSON Schemas for data maintained under
+`requirements/`.
+
+The first schemas will cover:
+
+- source bundle definitions
+- review decisions
+- test mappings
+- release baseline manifests
+
+These validate Conformance Map data and are separate from the GEISA API
+schemas being evaluated.

--- a/tools/conformance-map/README.md
+++ b/tools/conformance-map/README.md
@@ -1,0 +1,82 @@
+<!--
+Copyright 2025-2026, Contributors to the Grid Edge Interoperability &
+Security Alliance (GEISA), a Series of LF Projects, LLC
+
+Licensed under the Apache License, Version 2.0. See LICENSE.
+-->
+
+# GEISA Conformance Map
+
+GEISA Conformance Map will connect requirements in the GEISA specification and
+schemas to the tests in this repository.
+
+It is intended to show:
+
+- what a selected GEISA version requires for each conformance pillar
+- whether a requirement comes from specification text, protobufs, JSON Schemas,
+  or profiles
+- which current Cukinia tests cover each requirement
+- what is missing or only partially covered
+- what changed between a release and current development
+
+LEE and API are the initial focus. ADM and VEE are intentionally paused while
+coverage of the first two pillars is improved.
+
+## Approach
+
+The tool will use existing projects where possible instead of building a full
+requirements system from scratch:
+
+- Sphinx and Docutils for parsing the existing RST specification
+- Sphinx-Needs for linked requirement and test views where it fits
+- `protoc` descriptor sets for protobuf structure
+- Buf for protobuf linting and compatibility checks
+- `jsonschema` or `check-jsonschema` for JSON Schema validation
+
+GEISA-specific code will handle:
+
+- resolving sources and recording exact revisions
+- extracting requirement candidates
+- applying reviewed IDs and decisions
+- normalizing contract rules
+- scanning Cukinia tests
+- suggesting and storing approved mappings
+- determining applicability by pillar, profile, and advertised capability
+- comparing releases with current development
+- generating reports and optional test scaffolding
+
+## Intended workflow
+
+A normal run will:
+
+1. Resolve a release, commit, `latest`, or local workspace to an exact source state
+2. Extract requirement candidates and machine-defined contract rules
+3. Apply the reviewed decisions under `requirements/`
+4. Scan the existing Cukinia tests
+5. Suggest mappings and identify gaps
+6. Generate reports under `build/conformance-map/`
+
+Reviewed release baselines may be committed under `requirements/baselines/`.
+Results from current development or dirty workspaces remain generated output.
+
+## Planned commands
+
+The final command names may change as the initial implementation is tested.
+
+```text
+geisa-conformance-map inventory --target tag:v0.9.0
+geisa-conformance-map compare --baseline tag:v0.9.0 --target latest
+geisa-conformance-map report --target latest
+geisa-conformance-map scaffold --pillar LEE
+```
+
+## Repository layout
+
+- `requirements/` contains reviewed project data and release baselines
+- `tools/conformance-map/` contains the implementation and committed docs
+- `build/conformance-map/` contains generated output and is ignored by Git
+
+## Status
+
+General structure and initial documentation are in place, but implementation
+has not yet started.


### PR DESCRIPTION
## Summary

* the intent is to create a tool capable of parsing the specification (and protos/schemas) to map into
  actual existing tests and identify gaps to ensure a clear path to conformance coverage and coverage
  estimates
* creates the initial GEISA Conformance Map tool directory structure
* documents how specification requirements, schema contract rules, and Cukinia tests will be related
* establishes the reviewed data locations for requirements, mappings, baselines, and validation schemas
* documents the currently intended use of existing Sphinx, protobuf, Buf, and JSON Schema
* keeps any generated Conformance Map output outside version control

## Scope

* parsing of LEE and API are the initial focus, with ADM and VEE work on hold
* no parser or executable code exists yet