### PR TITLE
Add RST requirement candidate extraction

### DIFF
--- a/tools/conformance-map/README.md
+++ b/tools/conformance-map/README.md
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0. See LICENSE.
 # GEISA Conformance Map
 
 GEISA Conformance Map will connect requirements in the GEISA specification and
-schemas to the tests in this repository.
+schemas to the conformance tests in this repository.
 
 It is intended to show:
 
@@ -20,57 +20,127 @@ It is intended to show:
 - what changed between a release and current development
 
 LEE and API are the initial focus. ADM and VEE are intentionally paused while
-coverage of the first two pillars is improved.
+coverage and reporting on the first two pillars is improved.
 
 ## Approach
 
-The tool will use existing projects where possible instead of building a full
-requirements system from scratch:
+The tool builds on existing projects where possible rather than writing a full
+specification parser from scratch. The current code uses Docutils to parse RST
+specification text and GEISA-specific code to resolve local checkout details
+and extract requirement candidates.
 
-- Sphinx and Docutils for parsing the existing RST specification
-- Sphinx-Needs for linked requirement and test views where it fits
+Planned integrations include:
+
+- Sphinx and Sphinx-Needs for linked requirement and test views where feasible
 - `protoc` descriptor sets for protobuf structure
 - Buf for protobuf linting and compatibility checks
 - `jsonschema` or `check-jsonschema` for JSON Schema validation
 
-GEISA-specific code will handle:
+Planned GEISA-specific work includes:
 
-- resolving sources and recording exact revisions
-- extracting requirement candidates
 - applying reviewed IDs and decisions
 - normalizing contract rules
 - scanning Cukinia tests
 - suggesting and storing approved mappings
-- determining applicability by pillar, profile, and advertised capability
+- determining applicability by pillar, profile, and capability
 - comparing releases with current development
-- generating reports and optional test scaffolding
+- generating reports and optional future test scaffolding
 
-## Intended workflow
+## Planned workflow
 
-A normal run will:
+The planned workflow will:
 
-1. Resolve a release, commit, `latest`, or local workspace to an exact source state
-2. Extract requirement candidates and machine-defined contract rules
+1. Resolve a release, commit, `latest`, or local workspace to an exact source
+   state
+2. Extract requirement candidates and contract rules derived from schemas and
+   protocol definitions
 3. Apply the reviewed decisions under `requirements/`
 4. Scan the existing Cukinia tests
-5. Suggest mappings and identify gaps
+5. Suggest mappings and identify gaps where possible
 6. Generate reports under `build/conformance-map/`
 
 Reviewed release baselines may be committed under `requirements/baselines/`.
-Results from current development or dirty workspaces remain generated output.
 
-## Planned commands
+## Current workflow
 
-The final command names may change as the initial implementation is tested.
+Implemented today:
 
-```text
-geisa-conformance-map inventory --target tag:v0.9.0
-geisa-conformance-map compare --baseline tag:v0.9.0 --target latest
-geisa-conformance-map report --target latest
-geisa-conformance-map scaffold --pillar LEE
+1. Extract generated requirement candidates from LEE or API RST sources
+2. Write generated output under `build/conformance-map/`, which git ignores
+3. Preserve source and structural context for review
+
+Planned review and mapping work:
+
+1. Review candidates and split, merge, reject, or classify them
+2. Assign stable requirement IDs to reviewed requirements
+3. Discover/review existing conformance tests
+4. Propose requirement to test mappings
+5. Approve mappings through conformance team review
+6. Generate coverage, source-change, stale-test, and unmapped-requirement
+   reports (maybe)
+
+Note that a keyword or phrase occurrence is not automatically an independently
+testable requirement, and generated candidates are not automatically approved
+requirements. One test may cover several requirements, and one requirement
+may require several tests.  Proposed mappings should not be assumed to
+immediately be approved mappings or coverage until they are reviewed.
+
+## RST requirement extraction
+
+`extract-rst` currently supports the LEE and API pillars. It accepts the path
+to a local GEISA specification checkout, recursively scans the selected
+pillar's RST files, and records checkout details in the generated output:
+resolved path, branch, commit, and dirty state.
+
+The example below assumes the conformance and specification repositories are
+checked out as peers under the same GEISA workspace. Use `API` instead of
+`LEE` to extract API candidates.
+
+```sh
+geisa-conformance-map extract-rst \
+  --source ../specification \
+  --pillar LEE \
+  --output build/conformance-map/candidates/lee.yaml
 ```
 
+The extractor will output generated candidates. Each record has a repeatable
+candidate identifier for the generated source block.
+
+The extractor scans the selected pillar top-level source file when present and
+every RST file below `source/lee` or `source/api` recursively. It extracts
+paragraph and list-item blocks with explicit `MUST`, `MUST NOT`, `SHALL`, or
+`SHALL NOT` keywords. Each match records the normalized requirement keyword,
+the spelling found in the source, and whether the source used unusual
+capitalization. Totals include every match, including multiple requirement
+keywords in the same source block.
+
+Generated candidates retain the source path, section, approximate line,
+checkout branch, commit, list context, and standard or custom admonition
+context. Immediately following child lists and nested child lists are also
+retained.
+
+The tool currently processes RST specification text only. It does not yet
+process protobuf definitions or JSON Schemas, and it does not interpret table
+structures. Explicit requirement keywords in paragraph-like table cells may be
+extracted, but row, column, header, and other table meaning are not
+interpreted. Handling of tables are currently planned future work.
+
 ## Repository layout
+
+A typical GEISA development layout is:
+
+```text
+~/work/GEISA/
+├── conformance/
+├── specification/
+└── schemas/
+```
+
+`specification` is currently required by `extract-rst`. `schemas` is not
+required by `extract-rst` today, but later protobuf and JSON Schema extraction
+will use it. The repositories do not need to be peers when `--source` names a
+valid specification local checkout. The examples use peer checkouts as my
+preferred 'normal' GEISA development layout.
 
 - `requirements/` contains reviewed project data and release baselines
 - `tools/conformance-map/` contains the implementation and committed docs
@@ -81,10 +151,96 @@ geisa-conformance-map scaffold --pillar LEE
 Create the local development environment:
 
 ```sh
+cd ~/work/GEISA/conformance
 tools/conformance-map/setup-venv.sh
 source tools/conformance-map/.venv/bin/activate
+```
+
+## Running the extractor
+
+Make sure you've run setup-venv.sh and activated it as above.  The examples
+assume that `conformance` and `specification` are peer checkouts under
+`~/work/GEISA/`. Change `--source` as needed for your respective layout if
+needed.
+
+```sh
+geisa-conformance-map extract-rst \
+  --source ../specification \
+  --pillar LEE \
+  --output build/conformance-map/candidates/lee.yaml
+
+geisa-conformance-map extract-rst \
+  --source ../specification \
+  --pillar API \
+  --output build/conformance-map/candidates/api.yaml
+
+deactivate
+```
+
+LEE output is written to `build/conformance-map/candidates/lee.yaml`. API
+output is written to `build/conformance-map/candidates/api.yaml`. The current
+specification checkout produces ~25+ LEE candidates and 80+ API candidates
+against the 0.9.0 specification, but will change as both the tool and the
+specification changes.
+
+`build/conformance-map/` is set to be ignored by Git, and generated YAML files
+are not intended to be committed.
+
+Inspect the generated output with:
+
+```sh
+python - <<'PY'
+from pathlib import Path
+
+import yaml
+
+for pillar in ("lee", "api"):
+    path = Path(f"build/conformance-map/candidates/{pillar}.yaml")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    print(
+        pillar.upper(),
+        "candidates:",
+        data["candidate_count"],
+        "keyword matches:",
+        data["keyword_occurrence_count"],
+        "unusual capitalization:",
+        data["noncanonical_keyword_count"],
+    )
+PY
+```
+
+## Planned commands
+
+The final command names may change as the implementation is extended.
+
+```text
+geisa-conformance-map inventory --target tag:v0.9.0
+geisa-conformance-map compare --baseline tag:v0.9.0 --target latest
+geisa-conformance-map report --target latest
+geisa-conformance-map scaffold --pillar LEE
+```
 
 ## Status
 
-General structure and initial documentation are in place, but implementation
-has not yet started.
+Implemented:
+
+- RST extraction for LEE and API
+- Recognition of `MUST`, `MUST NOT`, `SHALL`, and `SHALL NOT`
+- Paragraph and list-item candidate extraction
+- Multiple keyword matches retained in one source block
+- Immediately following child lists and nested child lists retained
+- Standard and custom admonition context retained
+- Source path, section, approximate line, branch, commit, and dirty state
+  retained
+- Generated `requirement-candidate` records with repeatable candidate IDs
+
+Not yet implemented:
+
+- Protobuf definitions and descriptor-set extraction
+- JSON Schema extraction
+- Buf compatibility data
+- Handling of tables
+- Cukinia test discovery
+- Requirement-to-test mappings
+- Coverage reports

--- a/tools/conformance-map/src/geisa_conformance_map/cli.py
+++ b/tools/conformance-map/src/geisa_conformance_map/cli.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 
 from geisa_conformance_map import __version__
+from geisa_conformance_map.rst_extract import extract_candidates, write_candidates
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Build the command-line parser"""
+    """Build the command-line parser."""
 
     parser = argparse.ArgumentParser(
         prog="geisa-conformance-map",
@@ -25,14 +27,49 @@ def build_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"%(prog)s {__version__}",
     )
+
+    commands = parser.add_subparsers(dest="command")
+
+    extract_rst = commands.add_parser(
+        "extract-rst",
+        help="extract requirement candidates from GEISA RST sources",
+    )
+    extract_rst.add_argument(
+        "--source",
+        required=True,
+        type=Path,
+        help="path to a GEISA specification checkout",
+    )
+    extract_rst.add_argument(
+        "--pillar",
+        required=True,
+        choices=("API", "LEE"),
+        help="conformance pillar to extract",
+    )
+    extract_rst.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="generated YAML output path",
+    )
+
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run the CLI interface"""
+    """Run the command-line interface."""
 
     parser = build_parser()
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
+
+    if args.command == "extract-rst":
+        data = extract_candidates(args.source, args.pillar)
+        write_candidates(data, args.output)
+        print(
+            f"Wrote {data['candidate_count']} {data['pillar']} candidates "
+            f"to {args.output}"
+        )
+
     return 0
 
 

--- a/tools/conformance-map/src/geisa_conformance_map/rst_extract.py
+++ b/tools/conformance-map/src/geisa_conformance_map/rst_extract.py
@@ -1,0 +1,447 @@
+# Copyright 2025-2026, Contributors to the Grid Edge Interoperability &
+# Security Alliance (GEISA), a Series of LF Projects, LLC
+#
+# Licensed under the Apache License, Version 2.0. See LICENSE.
+
+"""Extract GEISA requirement candidates from RST source files."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from docutils import nodes
+from docutils.core import publish_doctree
+
+_REQUIREMENT_PATTERN = re.compile(
+    r"\b(MUST NOT|SHALL NOT|MUST|SHALL)\b",
+    flags=re.IGNORECASE,
+)
+
+_PILLAR_PATHS = {
+    "API": ("api.rst", "api"),
+    "LEE": ("linux-environment.rst", "lee"),
+}
+
+
+@dataclass(frozen=True)
+class SourceState:
+    """Resolved state of a local specification checkout."""
+
+    path: str
+    branch: str | None
+    commit: str | None
+    dirty: bool
+
+
+@dataclass(frozen=True)
+class CandidateContext:
+    """Source context used to build a requirement candidate."""
+
+    relative_path: str
+    pillar: str
+    document: nodes.document
+    paragraph: nodes.paragraph
+
+
+def _run_git(source: Path, *args: str) -> str | None:
+    """Run a read-only Git command and return stripped output."""
+
+    result = subprocess.run(
+        ["git", "-C", str(source), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def resolve_source_state(source: Path) -> SourceState:
+    """Resolve branch, commit, and dirty state for a local checkout."""
+
+    branch = _run_git(source, "branch", "--show-current")
+    commit = _run_git(source, "rev-parse", "HEAD")
+    status = _run_git(source, "status", "--short")
+
+    return SourceState(
+        path=str(source.resolve()),
+        branch=branch or None,
+        commit=commit or None,
+        dirty=bool(status),
+    )
+
+
+def _source_root(source: Path) -> Path:
+    """Return the RST source root for a GEISA specification checkout."""
+
+    candidate = source / "source"
+    if candidate.is_dir():
+        return candidate
+    return source
+
+
+def pillar_files(source: Path, pillar: str) -> list[Path]:
+    """Return RST files belonging to a supported conformance pillar."""
+
+    normalized = pillar.upper()
+    if normalized not in _PILLAR_PATHS:
+        supported = ", ".join(sorted(_PILLAR_PATHS))
+        raise ValueError(f"unsupported pillar {pillar!r}; expected one of {supported}")
+
+    root = _source_root(source)
+    top_level, directory = _PILLAR_PATHS[normalized]
+
+    files: list[Path] = []
+    top_level_path = root / top_level
+    if top_level_path.is_file():
+        files.append(top_level_path)
+
+    pillar_dir = root / directory
+    if pillar_dir.is_dir():
+        files.extend(sorted(pillar_dir.rglob("*.rst")))
+
+    if not files:
+        raise FileNotFoundError(f"no RST files found for {normalized} under {root}")
+
+    return files
+
+
+def _document_title(document: nodes.document) -> str | None:
+    """Return the document title when present."""
+
+    for child in document.children:
+        if isinstance(child, nodes.title):
+            return child.astext()
+    return None
+
+
+def _section_title(node: nodes.Node, document: nodes.document) -> str | None:
+    """Return the nearest section title or the document title."""
+
+    current = node.parent
+    while current is not None:
+        if isinstance(current, nodes.section):
+            for child in current.children:
+                if isinstance(child, nodes.title):
+                    return child.astext()
+        current = current.parent
+
+    return _document_title(document)
+
+
+def _list_path(node: nodes.Node) -> list[str]:
+    """Return labels from enclosing list items."""
+
+    labels: list[str] = []
+    current = node.parent
+
+    while current is not None:
+        if isinstance(current, nodes.list_item):
+            first_paragraph = next(
+                (
+                    child
+                    for child in current.children
+                    if isinstance(child, nodes.paragraph)
+                ),
+                None,
+            )
+            if first_paragraph is not None and first_paragraph is not node:
+                label = " ".join(first_paragraph.astext().split())
+                if label:
+                    labels.append(label)
+        current = current.parent
+
+    labels.reverse()
+    return labels
+
+
+def _candidate_id(path: str, line: int | None, source_text: str) -> str:
+    """Create a repeatable candidate identifier."""
+
+    value = f"{path}\n{line or 0}\n{source_text}".encode("utf-8")
+    digest = hashlib.sha256(value).hexdigest()[:16]
+    return f"rst:{path}:{line or 0}:{digest}"
+
+
+def _canonical_level(value: str) -> str:
+    """Return a requirement level in canonical uppercase form."""
+
+    return " ".join(value.upper().split())
+
+
+def _matches(source_text: str) -> list[dict[str, Any]]:
+    """Return requirement keyword matches within one source block."""
+
+    matches: list[dict[str, Any]] = []
+
+    for match in _REQUIREMENT_PATTERN.finditer(source_text):
+        source_keyword = match.group(1)
+        canonical = _canonical_level(source_keyword)
+
+        matches.append(
+            {
+                "level": canonical,
+                "source_keyword": source_keyword,
+                "noncanonical_case": source_keyword != canonical,
+                "start": match.start(),
+                "end": match.end(),
+            }
+        )
+
+    return matches
+
+
+def _serialize_list_item(item: nodes.list_item) -> dict[str, Any]:
+    """Serialize one list item and any nested lists."""
+
+    paragraphs = [
+        " ".join(child.astext().split())
+        for child in item.children
+        if isinstance(child, nodes.paragraph)
+    ]
+
+    result: dict[str, Any] = {
+        "text": " ".join(paragraphs).strip(),
+    }
+
+    children: list[dict[str, Any]] = []
+
+    for child in item.children:
+        if isinstance(child, (nodes.bullet_list, nodes.enumerated_list)):
+            children.extend(
+                _serialize_list_item(grandchild)
+                for grandchild in child.children
+                if isinstance(grandchild, nodes.list_item)
+            )
+
+    if children:
+        result["children"] = children
+
+    return result
+
+
+def _following_list(paragraph: nodes.paragraph) -> list[dict[str, Any]]:
+    """Return a list immediately following the paragraph."""
+
+    parent = paragraph.parent
+    if parent is None:
+        return []
+
+    try:
+        index = parent.children.index(paragraph)
+    except ValueError:
+        return []
+
+    if index + 1 >= len(parent.children):
+        return []
+
+    sibling = parent.children[index + 1]
+
+    if not isinstance(sibling, (nodes.bullet_list, nodes.enumerated_list)):
+        return []
+
+    return [
+        _serialize_list_item(item)
+        for item in sibling.children
+        if isinstance(item, nodes.list_item)
+    ]
+
+
+def _admonition_context(
+    paragraph: nodes.paragraph,
+) -> dict[str, Any] | None:
+    """Describe the nearest enclosing RST admonition."""
+
+    current = paragraph.parent
+
+    while current is not None:
+        if isinstance(current, nodes.Admonition):
+            title = next(
+                (
+                    child.astext()
+                    for child in current.children
+                    if isinstance(child, nodes.title)
+                ),
+                None,
+            )
+
+            result: dict[str, Any] = {
+                "type": current.tagname,
+                "title": title,
+            }
+
+            classes = list(current.get("classes", []))
+            if classes:
+                result["classes"] = classes
+
+            return result
+
+        current = current.parent
+
+    return None
+
+
+def _candidate(
+    context: CandidateContext,
+    source_text: str,
+    matches: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build one reviewable source-block candidate."""
+
+    line = context.paragraph.line
+    list_path = _list_path(context.paragraph)
+    children = _following_list(context.paragraph)
+    admonition = _admonition_context(context.paragraph)
+
+    candidate: dict[str, Any] = {
+        "type": "requirement-candidate",
+        "candidate_id": _candidate_id(
+            context.relative_path,
+            line,
+            source_text,
+        ),
+        "pillar": context.pillar.upper(),
+        "source": {
+            "path": context.relative_path,
+            "document": _document_title(context.document),
+            "section": _section_title(
+                context.paragraph,
+                context.document,
+            ),
+            "line_start": line,
+            "line_end": line,
+        },
+        "requirement": {
+            "source_text": source_text,
+            "matches": matches,
+        },
+    }
+
+    candidate_context: dict[str, Any] = {}
+
+    if list_path:
+        candidate_context["list_path"] = list_path
+
+    if admonition:
+        candidate_context["admonition"] = admonition
+
+    if candidate_context:
+        candidate["context"] = candidate_context
+
+    if children:
+        candidate["children"] = children
+
+    return candidate
+
+
+def extract_file(path: Path, root: Path, pillar: str) -> dict[str, Any]:
+    """Extract candidate requirements and audit data from one RST file."""
+
+    text = path.read_text(encoding="utf-8")
+    document = publish_doctree(
+        source=text,
+        source_path=str(path),
+        settings_overrides={
+            "halt_level": 5,
+            "report_level": 5,
+            "warning_stream": None,
+            "raw_enabled": False,
+            "file_insertion_enabled": False,
+        },
+    )
+
+    relative_path = path.relative_to(root.parent).as_posix()
+    candidates: list[dict[str, Any]] = []
+    keyword_occurrences = 0
+    noncanonical_keywords = 0
+
+    for paragraph in document.findall(nodes.paragraph):
+        source_text = " ".join(paragraph.astext().split())
+        matches = _matches(source_text)
+
+        if not matches:
+            continue
+
+        keyword_occurrences += len(matches)
+        noncanonical_keywords += sum(
+            1 for match in matches if match["noncanonical_case"]
+        )
+
+        candidates.append(
+            _candidate(
+                CandidateContext(
+                    relative_path=relative_path,
+                    pillar=pillar,
+                    document=document,
+                    paragraph=paragraph,
+                ),
+                source_text,
+                matches,
+            )
+        )
+
+    return {
+        "candidates": candidates,
+        "audit": {
+            "path": relative_path,
+            "candidate_blocks": len(candidates),
+            "keyword_occurrences": keyword_occurrences,
+            "noncanonical_keywords": noncanonical_keywords,
+        },
+    }
+
+
+def extract_candidates(source: Path, pillar: str) -> dict[str, Any]:
+    """Extract candidate requirements for one pillar."""
+
+    source = source.resolve()
+    root = _source_root(source)
+    state = resolve_source_state(source)
+
+    candidates: list[dict[str, Any]] = []
+    files: list[dict[str, Any]] = []
+
+    for path in pillar_files(source, pillar):
+        result = extract_file(path, root, pillar)
+        candidates.extend(result["candidates"])
+        files.append(result["audit"])
+
+    return {
+        "source": {
+            "path": state.path,
+            "branch": state.branch,
+            "commit": state.commit,
+            "dirty": state.dirty,
+        },
+        "pillar": pillar.upper(),
+        "candidate_count": len(candidates),
+        "keyword_occurrence_count": sum(item["keyword_occurrences"] for item in files),
+        "noncanonical_keyword_count": sum(
+            item["noncanonical_keywords"] for item in files
+        ),
+        "audit": {
+            "files": files,
+        },
+        "candidates": candidates,
+    }
+
+
+def write_candidates(data: dict[str, Any], output: Path) -> None:
+    """Write extracted candidates as YAML."""
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        yaml.safe_dump(
+            data,
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )

--- a/tools/conformance-map/tests/fixtures/specification/source/lee/admonitions.rst
+++ b/tools/conformance-map/tests/fixtures/specification/source/lee/admonitions.rst
@@ -1,0 +1,11 @@
+Admonition Requirements
+========================
+
+.. note::
+
+   Implementations SHALL NOT infer behavior from this reserved section.
+
+.. admonition:: Status: Reserved for Future Definition
+   :class: tbd-section
+
+   Platforms MUST reject operations that rely on undefined behavior.

--- a/tools/conformance-map/tests/fixtures/specification/source/lee/app-isolation.rst
+++ b/tools/conformance-map/tests/fixtures/specification/source/lee/app-isolation.rst
@@ -1,0 +1,25 @@
+Application Isolation
+=====================
+
+Applications SHALL not run as root.
+
+Platform implementations MUST provide:
+
+- a shared base image
+
+  - a hardened base image
+- application image support
+
+Networking
+----------
+
+Applications MUST be denied direct network access by default.
+
+- /tmp
+
+  - MUST be limited in size as described in the deployment manifest
+
+Applications may use another library, otherwise they must bring their own.
+
+Platform implementations MUST retain application state and SHALL NOT discard it
+before a requested reset.

--- a/tools/conformance-map/tests/fixtures/specification/source/lee/nested/storage.rst
+++ b/tools/conformance-map/tests/fixtures/specification/source/lee/nested/storage.rst
@@ -1,0 +1,4 @@
+Nested Storage Requirements
+===========================
+
+Persistent storage MUST survive application restarts.

--- a/tools/conformance-map/tests/fixtures/specification/source/linux-environment.rst
+++ b/tools/conformance-map/tests/fixtures/specification/source/linux-environment.rst
@@ -1,0 +1,6 @@
+Linux Execution Environment
+===========================
+
+.. toctree::
+
+   lee/app-isolation

--- a/tools/conformance-map/tests/test_rst_extract.py
+++ b/tools/conformance-map/tests/test_rst_extract.py
@@ -1,0 +1,147 @@
+# Copyright 2025-2026, Contributors to the Grid Edge Interoperability &
+# Security Alliance (GEISA), a Series of LF Projects, LLC
+#
+# Licensed under the Apache License, Version 2.0. See LICENSE.
+
+"""Tests for RST requirement extraction."""
+
+from pathlib import Path
+
+import yaml
+
+from geisa_conformance_map.cli import main
+from geisa_conformance_map.rst_extract import extract_candidates
+
+FIXTURE = Path(__file__).parent / "fixtures" / "specification"
+
+
+def test_extracts_reviewable_blocks_with_context() -> None:
+    """LEE extraction should retain matches, sections, lists, and case."""
+
+    data = extract_candidates(FIXTURE, "LEE")
+
+    assert data["pillar"] == "LEE"
+    assert data["candidate_count"] == 9
+    assert data["keyword_occurrence_count"] == 10
+    assert data["noncanonical_keyword_count"] == 2
+
+    candidates = data["candidates"]
+
+    nonroot_candidate = next(
+        candidate
+        for candidate in candidates
+        if candidate["requirement"]["source_text"]
+        == "Applications SHALL not run as root."
+    )
+    assert nonroot_candidate["type"] == "requirement-candidate"
+    assert nonroot_candidate["source"]["document"] == "Application Isolation"
+    assert nonroot_candidate["source"]["section"] == "Application Isolation"
+    assert nonroot_candidate["requirement"]["matches"][0] == {
+        "level": "SHALL NOT",
+        "source_keyword": "SHALL not",
+        "noncanonical_case": True,
+        "start": 13,
+        "end": 22,
+    }
+
+    grouped_candidate = next(
+        candidate
+        for candidate in candidates
+        if candidate["requirement"]["source_text"]
+        == "Platform implementations MUST provide:"
+    )
+    assert grouped_candidate["children"] == [
+        {
+            "text": "a shared base image",
+            "children": [{"text": "a hardened base image"}],
+        },
+        {"text": "application image support"},
+    ]
+
+    aggregate_candidate = next(
+        candidate
+        for candidate in candidates
+        if candidate["requirement"]["source_text"]
+        == (
+            "Platform implementations MUST retain application state and SHALL NOT "
+            "discard it before a requested reset."
+        )
+    )
+    assert [
+        match["level"] for match in aggregate_candidate["requirement"]["matches"]
+    ] == [
+        "MUST",
+        "SHALL NOT",
+    ]
+
+    tmp_candidate = next(
+        candidate
+        for candidate in candidates
+        if candidate.get("context", {}).get("list_path") == ["/tmp"]
+    )
+    assert tmp_candidate["requirement"]["source_text"] == (
+        "MUST be limited in size as described in the deployment manifest"
+    )
+
+    lowercase_candidate = next(
+        candidate
+        for candidate in candidates
+        if "must bring their own" in candidate["requirement"]["source_text"]
+    )
+    assert lowercase_candidate["requirement"]["matches"][0]["noncanonical_case"] is True
+
+    nested_candidate = next(
+        candidate
+        for candidate in candidates
+        if candidate["source"]["path"] == "source/lee/nested/storage.rst"
+    )
+    assert nested_candidate["requirement"]["source_text"] == (
+        "Persistent storage MUST survive application restarts."
+    )
+
+    note_candidate = next(
+        candidate
+        for candidate in candidates
+        if "infer behavior" in candidate["requirement"]["source_text"]
+    )
+    assert note_candidate["context"]["admonition"] == {
+        "type": "note",
+        "title": None,
+    }
+
+    reserved_candidate = next(
+        candidate
+        for candidate in candidates
+        if "reject operations" in candidate["requirement"]["source_text"]
+    )
+    assert reserved_candidate["context"]["admonition"] == {
+        "type": "admonition",
+        "title": "Status: Reserved for Future Definition",
+        "classes": ["tbd-section"],
+    }
+
+
+def test_cli_writes_yaml(tmp_path: Path) -> None:
+    """The CLI should write generated candidates as YAML."""
+
+    output = tmp_path / "lee.yaml"
+
+    result = main(
+        [
+            "extract-rst",
+            "--source",
+            str(FIXTURE),
+            "--pillar",
+            "LEE",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+
+    data = yaml.safe_load(output.read_text(encoding="utf-8"))
+
+    assert data["candidate_count"] == 9
+    assert data["keyword_occurrence_count"] == 10
+    assert data["noncanonical_keyword_count"] == 2


### PR DESCRIPTION
## Summary

Adds the first working GEISA Conformance Map extractor for LEE and API RST sources.

## Changes

* adds the `extract-rst` command
* recursively scans the selected LEE or API RST sources
* records source checkout details and document context
* captures requirement keywords, list context, nested child lists, and admonitions
* reports unusual requirement-keyword capitalization
* adds focused fixtures and tests
* documents setup, extraction, generated output, and current limitations

Generated records remain requirement candidates and do not represent reviewed requirements or requirement IDs.

## Validation

* Pytest: 3 passed
* Pylint: 10.00/10
* Markdown lint passed
* `git diff --check` passed
* real extraction produced 29 LEE candidates and 83 API candidates on the current specification
